### PR TITLE
Fixing CMake SDK external project pull for older CMake versions (3.10+).

### DIFF
--- a/CMakeLists.txt.awssdk
+++ b/CMakeLists.txt.awssdk
@@ -6,7 +6,6 @@ include(ExternalProject)
 ExternalProject_Add(aws-iot-device-sdk-cpp-v2
         GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
         GIT_TAG                 026f5718ac0eb1f99bae10157efca9f1ac2386b1
-        GIT_SUBMODULES_RECURSE  true
         SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
         CONFIGURE_COMMAND       ""


### PR DESCRIPTION
*Description of changes:*

* Removed the `GIT_SUBMODULES_RECURSE` option for the SDK ExternalProject_Add

The CMake ExternalProject option for Git `GIT_SUBMODULES_RECURSE` was not available until CMake 3.18: https://cmake.org/cmake/help/v3.18/module/ExternalProject.html

The documentation for 3.10 shows the following: https://cmake.org/cmake/help/v3.10/module/ExternalProject.html

```
GIT_SUBMODULES <module>...

    Specific git submodules that should also be updated. If this option is not provided, all git submodules will be updated.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
