### PR TITLE
Ignore duplicate MQTT new tunnel notifications

### DIFF
--- a/source/tunneling/SecureTunnelingFeature.h
+++ b/source/tunneling/SecureTunnelingFeature.h
@@ -85,6 +85,8 @@ namespace Aws
                     // On demand
                     std::unique_ptr<Aws::Iotsecuretunneling::SecureTunnel> mSecureTunnel;
                     std::unique_ptr<TcpForward> mTcpForward;
+
+                    Aws::Crt::Optional<Aws::Iotsecuretunneling::SecureTunnelingNotifyResponse> mLastSeenNotifyResponse;
                 };
             } // namespace SecureTunneling
         }     // namespace DeviceClient


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Save the latest new tunnel notification and ignore new one if the new one is the same as the latest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
