### PR TITLE
Handle sending data to socket before socket is connected

### DIFF
--- a/source/tunneling/TcpForward.h
+++ b/source/tunneling/TcpForward.h
@@ -44,6 +44,8 @@ namespace Aws
                     void OnWriteCompleted(struct aws_socket *socket, int error_code, size_t bytes_written);
                     void OnReadable(struct aws_socket *socket, int error_code);
 
+                    void FlushSendBuffer();
+
                     // Member data
                     static constexpr char TAG[] = "TcpForward.cpp";
 
@@ -55,6 +57,8 @@ namespace Aws
                     OnTcpForwardDataReceive mOnTcpForwardDataReceive;
 
                     aws_socket mSocket{};
+                    bool mConnected;
+                    Aws::Crt::ByteBuf mSendBuffer;
                 };
             } // namespace SecureTunneling
         }     // namespace DeviceClient


### PR DESCRIPTION
The secure tunneling protocol asks to connect to local service *when* `StreamStart` is received. However `DATA` stream can follow right after `StreamStart`. Because connecting to a socket is an async operation, DC needs to handle `DATA` stream when the socket is not connected yet.

This PR creates a buffer to store this `DATA` stream. As soon as the socket is connected, we write this buffer to the socket.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
