### PR TITLE
Don't read access token, region and port from json for Secure Tunneling

### DIFF
--- a/dc-settings.json
+++ b/dc-settings.json
@@ -8,8 +8,7 @@
 		"enabled": false
 	},
 	"tunneling": {
-		"enabled": false,
-		"subscribe-notification": true
+		"enabled": false
 	},
 	"device-defender":	{
 		"enabled":	false,

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -362,9 +362,7 @@ constexpr char PlainConfig::Tunneling::CLI_TUNNELING_DISABLE_NOTIFICATION[];
 constexpr char PlainConfig::Tunneling::CLI_TUNNELING_DESTINATION_ACCESS_TOKEN[];
 constexpr char PlainConfig::Tunneling::CLI_TUNNELING_REGION[];
 constexpr char PlainConfig::Tunneling::CLI_TUNNELING_SERVICE[];
-
 constexpr char PlainConfig::Tunneling::JSON_KEY_ENABLED[];
-constexpr char PlainConfig::Tunneling::JSON_KEY_SUBSCRIBE_NOTIFICATION[];
 
 bool PlainConfig::Tunneling::LoadFromJson(const Crt::JsonView &json)
 {
@@ -372,12 +370,6 @@ bool PlainConfig::Tunneling::LoadFromJson(const Crt::JsonView &json)
     if (json.ValueExists(jsonKey))
     {
         enabled = json.GetBool(jsonKey);
-    }
-
-    jsonKey = JSON_KEY_SUBSCRIBE_NOTIFICATION;
-    if (json.ValueExists(jsonKey))
-    {
-        subscribeNotification = json.GetBool(jsonKey);
     }
 
     return true;
@@ -726,7 +718,6 @@ void Config::ExportDefaultSetting(const string &file)
         "%s": true
     },
     "%s": {
-        "%s": true,
         "%s": true
     },
     "%s": {
@@ -748,7 +739,6 @@ void Config::ExportDefaultSetting(const string &file)
         PlainConfig::Jobs::JSON_KEY_ENABLED,
         PlainConfig::JSON_KEY_TUNNELING,
         PlainConfig::Tunneling::JSON_KEY_ENABLED,
-        PlainConfig::Tunneling::JSON_KEY_SUBSCRIBE_NOTIFICATION,
         PlainConfig::JSON_KEY_DEVICE_DEFENDER,
         PlainConfig::DeviceDefender::JSON_KEY_ENABLED,
         PlainConfig::DeviceDefender::JSON_KEY_INTERVAL);

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -104,9 +104,7 @@ namespace Aws
                         "--tunneling-destination-access-token";
                     static constexpr char CLI_TUNNELING_REGION[] = "--tunneling-region";
                     static constexpr char CLI_TUNNELING_SERVICE[] = "--tunneling-service";
-
                     static constexpr char JSON_KEY_ENABLED[] = "enabled";
-                    static constexpr char JSON_KEY_SUBSCRIBE_NOTIFICATION[] = "subscribe-notification";
 
                     bool enabled{false};
                     bool subscribeNotification{true};

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -200,94 +200,27 @@ TEST(Config, SecureTunnelingDisableSubscription)
 	"root-ca": "root-ca value",
 	"thing-name": "thing-name value",
     "tunneling": {
-        "enabled": true,
-        "subscribe-notification": false,
-        "destination-access-token": "destination access token value",
-        "region": "region value",
-        "port": 65535
+        "enabled": true
     }
 })";
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
+    CliArgs cliArgs;
+    cliArgs["--tunneling-disable-notification"] = "";
+    cliArgs["--tunneling-destination-access-token"] = "destination access token value";
+    cliArgs["--tunneling-region"] = "region value";
+    cliArgs["--tunneling-service"] = "SSH";
 
     PlainConfig config;
     config.LoadFromJson(jsonView);
+    config.LoadFromCliArgs(cliArgs);
 
     ASSERT_TRUE(config.Validate());
     ASSERT_TRUE(config.tunneling.enabled);
     ASSERT_FALSE(config.tunneling.subscribeNotification);
     ASSERT_STREQ("destination access token value", config.tunneling.destinationAccessToken->c_str());
     ASSERT_STREQ("region value", config.tunneling.region->c_str());
-    ASSERT_EQ(65535, config.tunneling.port.value());
-}
-
-TEST(Config, SecureTunnelingPortRange)
-{
-    // Too small
-    const char *jsonString = R"(
-{
-    "enabled": true,
-    "subscribe-notification": false,
-    "destination-access-token": "destination access token value",
-    "region": "region value",
-    "port": 0
-})";
-    unique_ptr<JsonObject> jsonObject = unique_ptr<JsonObject>(new JsonObject(jsonString));
-    JsonView jsonView = jsonObject->View();
-    unique_ptr<PlainConfig> config = unique_ptr<PlainConfig>(new PlainConfig());
-    config->tunneling.LoadFromJson(jsonView);
-#if !defined(EXCLUDE_ST)
-    ASSERT_FALSE(config->tunneling.Validate());
-#endif
-
-    // Negative port
-    jsonString = R"(
-{
-    "enabled": true,
-    "subscribe-notification": false,
-    "destination-access-token": "destination access token value",
-    "region": "region value",
-    "port": -1
-})";
-    jsonObject = unique_ptr<JsonObject>(new JsonObject(jsonString));
-    jsonView = jsonObject->View();
-    config = unique_ptr<PlainConfig>(new PlainConfig());
-    config->tunneling.LoadFromJson(jsonView);
-#if !defined(EXCLUDE_ST)
-    ASSERT_FALSE(config->tunneling.Validate());
-#endif
-
-    // Too large
-    jsonString = R"(
-{
-    "enabled": true,
-    "subscribe-notification": false,
-    "destination-access-token": "destination access token value",
-    "region": "region value",
-    "port": 65536
-})";
-    jsonObject = unique_ptr<JsonObject>(new JsonObject(jsonString));
-    jsonView = jsonObject->View();
-    config = unique_ptr<PlainConfig>(new PlainConfig());
-    config->tunneling.LoadFromJson(jsonView);
-#if !defined(EXCLUDE_ST)
-    ASSERT_FALSE(config->tunneling.Validate());
-#endif
-
-    // Within range
-    jsonString = R"(
-{
-    "enabled": true,
-    "subscribe-notification": false,
-    "destination-access-token": "destination access token value",
-    "region": "region value",
-    "port": 22
-})";
-    jsonObject = unique_ptr<JsonObject>(new JsonObject(jsonString));
-    jsonView = jsonObject->View();
-    config = unique_ptr<PlainConfig>(new PlainConfig());
-    config->tunneling.LoadFromJson(jsonView);
-    ASSERT_TRUE(config->tunneling.Validate());
+    ASSERT_EQ(22, config.tunneling.port.value());
 }
 
 TEST(Config, LoggingConfigurationCLI)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
