### PR TITLE
Fix for build script only caring if tests pass

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -51,6 +51,10 @@ cd ./build/
 
 cmake ../ -DBUILD_SDK=OFF -DBUILD_TEST_DEPS=OFF
 cmake --build . --target aws-iot-device-client
+if [ $? != 0 ]
+then
+  exit 1
+fi
 cmake --build . --target test-aws-iot-device-client
 
 ### Run Tests ###


### PR DESCRIPTION
*Description of changes:*
Build script was only caring if the unit tests pass.  It should return on whether everything builds successfully too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
