### PR TITLE
Doesn't require config file to start

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -887,12 +887,12 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 bool Config::init(const CliArgs &cliArgs)
 {
     string filename = Config::DEFAULT_CONFIG_FILE;
-    bool bReadConfigFile = FileExists(filename);
+    bool bReadConfigFile = FileUtils::FileExists(filename);
 
     if (cliArgs.count(Config::CLI_CONFIG_FILE))
     {
         filename = cliArgs.at(Config::CLI_CONFIG_FILE);
-        if (!FileExists(filename))
+        if (!FileUtils::FileExists(filename))
         {
             LOGM_ERROR(
                 TAG,
@@ -958,7 +958,7 @@ bool Config::ValidateAndStoreRuntimeConfig()
 bool Config::ParseConfigFile(const string &file, bool isRuntimeConfig)
 {
     string expandedPath = FileUtils::ExtractExpandedPath(file.c_str());
-    if (!FileExists(expandedPath))
+    if (!FileUtils::FileExists(expandedPath))
     {
         if (!isRuntimeConfig)
         {
@@ -1012,13 +1012,6 @@ bool Config::ParseConfigFile(const string &file, bool isRuntimeConfig)
     setting.close();
 
     return true;
-}
-
-bool Config::FileExists(const string &filename)
-{
-    string expandedPath = FileUtils::ExtractExpandedPath(filename.c_str());
-    ifstream f(expandedPath);
-    return f.good();
 }
 
 void Config::PrintHelpMessage()

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -235,7 +235,6 @@ namespace Aws
                 PlainConfig config;
 
               private:
-                static bool FileExists(const std::string &filename);
                 static void PrintHelpMessage();
                 static bool ExportDefaultSetting(const std::string &file);
             };

--- a/source/util/FileUtils.cpp
+++ b/source/util/FileUtils.cpp
@@ -246,3 +246,10 @@ bool FileUtils::CreateDirectoryWithPermissions(const char *dirPath, mode_t permi
     LOGM_ERROR(TAG, "Failed to create directory %s", Sanitize(expandedPath).c_str());
     return false;
 }
+
+bool FileUtils::FileExists(const string &filename)
+{
+    string expandedPath = FileUtils::ExtractExpandedPath(filename.c_str());
+    ifstream f(expandedPath);
+    return f.good();
+}

--- a/source/util/FileUtils.h
+++ b/source/util/FileUtils.h
@@ -114,6 +114,14 @@ namespace Aws
                      * otherwise
                      */
                     static bool CreateDirectoryWithPermissions(const char *dirPath, mode_t permissions);
+
+                    /**
+                     * \brief Check if the given filename exists
+                     *
+                     * @param filename Filename to check
+                     * @return True if the file exists. False otherwise.
+                     */
+                    static bool FileExists(const std::string &filename);
                 };
             } // namespace Util
         }     // namespace DeviceClient

--- a/test/util/TestFileUtils.cpp
+++ b/test/util/TestFileUtils.cpp
@@ -216,3 +216,14 @@ TEST(FileUtils, setupDirectoryDetectedSetupFailure)
 
     ASSERT_FALSE(didSetup);
 }
+
+TEST(FileUtils, FileExists)
+{
+    string filePath = "/tmp/" + UniqueString::GetRandomToken(10);
+    ofstream file(filePath, std::fstream::app);
+    file << "test message" << endl;
+    ASSERT_TRUE(FileUtils::FileExists(filePath));
+
+    std::remove(filePath.c_str());
+    ASSERT_FALSE(FileUtils::FileExists(filePath));
+}


### PR DESCRIPTION
### Description of changes:
* Allow Device Client to start without any configuration file

### Testing done:
1. Start DC without any configuration file. (Pass all arguments through CLI.)
2. Start DC with only the default configuration file, no CLI argument.
3. Start DC with only the config file specified by the CLI. (Default config file is missing, no CLI.)
4. Start DC with both config files and make sure the one specified in the CLI is used.
5. Start DC with CLI argument pointing to a missing config file and make sure DC doesn't start

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.