### PR TITLE
Change to DD config variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ $ ./aws-iot-device-client --enable-device-defender --device-defender-interval 30
   ...
  "device-defender":	{
 		"enabled":	true,
-		"interval-in-seconds": 300
+		"interval": 300
   }
   ...
 }

--- a/config-template.json
+++ b/config-template.json
@@ -17,8 +17,8 @@
 		"enabled": true
 	},
 	"device-defender":	{
-		"enabled":	true,
-		"interval-in-seconds": 300
+		"enabled": true,
+		"interval": 300
 	},
 	"fleet-provisioning": {
 		"enabled": false,

--- a/setup.sh
+++ b/setup.sh
@@ -155,7 +155,7 @@ if [ "$BUILD_CONFIG" = "y" ]; then
       },
       \"device-defender\":	{
         \"enabled\":	$DD_ENABLED,
-        \"interval-in-seconds\": $DD_INTERVAL
+        \"interval\": $DD_INTERVAL
       },
       \"fleet-provisioning\":	{
         \"enabled\":	$FP_ENABLED,

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1045,7 +1045,7 @@ void Config::PrintHelpMessage()
         "%s <region>:\t\t\t\t\t\tUse Specified AWS Region for Secure Tunneling\n"
         "%s <service>:\t\t\t\t\t\tConnect secure tunnel to specific service\n"
         "%s:\t\t\t\t\tDisable MQTT new tunnel notification for Secure Tunneling\n"
-        "%s <interval-in-seconds>:\t\t\tPositive integer to publish Device Defender metrics\n"
+        "%s <interval>:\t\t\tPositive integer to publish Device Defender metrics\n"
         "%s <template-name>:\t\t\tUse specified Fleet Provisioning template name\n"
         "%s <csr-file-path>:\t\t\t\t\t\tUse specified CSR file to generate a certificate by keeping user private key "
         "secure. "

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -162,7 +162,7 @@ namespace Aws
                     static constexpr char CLI_DEVICE_DEFENDER_INTERVAL[] = "--device-defender-interval";
 
                     static constexpr char JSON_KEY_ENABLED[] = "enabled";
-                    static constexpr char JSON_KEY_INTERVAL[] = "interval-in-seconds";
+                    static constexpr char JSON_KEY_INTERVAL[] = "interval";
 
                     bool enabled{true};
                     int interval{300};

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -32,7 +32,7 @@ TEST(Config, AllFeaturesEnabled)
     },
     "device-defender": {
         "enabled": true,
-        "interval-in-seconds": 300
+        "interval": 300
     }
 })";
     JsonObject jsonObject(jsonString);


### PR DESCRIPTION
*Description of changes:*
config variable `interval` requested to be more homogenized with `--device-defender-interval`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
