### PR TITLE
Fix Ubi8 and Al2 Dockerfile Openssl install

### DIFF
--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -33,11 +33,10 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 WORKDIR /tmp
 RUN wget https://www.openssl.org/source/openssl-1.1.1i.tar.gz \
     && tar -zxvf openssl-1.1.1i.tar.gz \
-    && cd openssl-1.1.1i.tar.gz \
+    && cd openssl-1.1.1i \
     && ./config \
     && make \
-    && sudo make install \
-    && sudo ln -s /usr/local/bin/openssl /usr/bin/openssl
+    && sudo make install
 
 ###############################################################################
 # Clone and build Google Test

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -34,11 +34,10 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 WORKDIR /tmp
 RUN wget https://www.openssl.org/source/openssl-1.1.1i.tar.gz \
     && tar -zxvf openssl-1.1.1i.tar.gz \
-    && cd openssl-1.1.1i.tar.gz \
+    && cd openssl-1.1.1i \
     && ./config \
     && make \
-    && sudo make install \
-    && sudo ln -s /usr/local/bin/openssl /usr/bin/openssl
+    && sudo make install
 
 ###############################################################################
 # Clone and build Google Test


### PR DESCRIPTION
There was an issue with the existing Dockerfiles for OpenSSL installation. This commit addresses the issue by changing the instructions and eliminating a binary linking step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
