### PR TITLE
Add abort if MQTT client configuration fails

### DIFF
--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -157,7 +157,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
             TAG,
             "MQTT Client Configuration initialization failed with error: %s",
             ErrorDebugString(clientConfig.LastError()));
-        return clientConfig.LastError();
+        return ABORT;
     }
 
     connection = mqttClient->NewConnection(clientConfig);
@@ -165,7 +165,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     if (!*connection)
     {
         LOGM_ERROR(TAG, "MQTT Connection Creation failed with error: %s", ErrorDebugString(connection->LastError()));
-        return connection->LastError();
+        return ABORT;
     }
 
     promise<int> connectionCompletedPromise;
@@ -211,7 +211,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     if (!connection->Connect(config.thingName->c_str(), true, 0))
     {
         LOGM_ERROR(TAG, "MQTT Connection failed with error: %s", ErrorDebugString(connection->LastError()));
-        return connection->LastError();
+        return RETRY;
     }
 
     int connectionStatus = connectionCompletedPromise.get_future().get();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -137,15 +137,15 @@ void attemptConnection()
                 DC_FATAL_ERROR);
             LoggerFactory::getLoggerInstance()->shutdown();
             deviceClientAbort("Failed to establish MQTT connection due to credential/configuration error");
-            return false;
+            return true;
         }
-        else if (SharedCrtResourceManager::RETRY == connectionStatus)
+        else if (SharedCrtResourceManager::SUCCESS == connectionStatus)
         {
-            return false;
+            return true;
         }
         else
         {
-            return true;
+            return false;
         }
     };
     std::thread attemptConnectionThread(&Retry::exponentialBackoff, publishLambda, retryConfig);


### PR DESCRIPTION
This commit addresses an issue where we may continue with feature startup even if we fail to build the MQTT client. The issue was caused by bubbling up the return code of an SDK function when we should just be returning the ABORT constant.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
