### PR TITLE
Added support for new config option for taking device private key location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - SDK logging now configurable via CLI or JSON
-- Support for configuring Device Private Key via CLI and JSON 
+- Support for configuring Device Private Key via CLI and JSON for Fleet provisioning using CreateCertificateFromCsr API 
 
 ## [1.0.X] - 2021-01-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - SDK logging now configurable via CLI or JSON
+- Support for configuring Device Private Key via CLI and JSON 
 
 ## [1.0.X] - 2021-01-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -558,9 +558,9 @@ More details about AWS IoT Fleet Provisioning by claim can be found here: https:
 
 *Note: If the fleet provisioning feature fails to provision the new key, certificate or thing/device, the device client will abort with fatal error.*
 
-*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
+*Note: If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to generate new Certificate and Private Key while provisioning the device*
 
-*Note: Please make sure that the Claim certificate, private key and/or CSR file, device private key stored on device side have respective permissions applied to it as mentioned above in the "File and Directory Permissions" section of the readme.*
+*Note: Please make sure that the Claim certificate, private key, CSR file and/or device private key stored on device side have respective permissions applied to it as mentioned above in the "File and Directory Permissions" section of the readme.*
 
 Refer to the [CreateKeysAndCertificate](https://docs.aws.amazon.com/iot/latest/developerguide/fleet-provision-api.html#create-keys-cert) and [CreateCertificateFromCsr](https://docs.aws.amazon.com/iot/latest/developerguide/fleet-provision-api.html#create-cert-csr) APIs for more details.
 
@@ -747,7 +747,7 @@ To get started with the feature you will need to set the right configuration. Th
 
 `device-key`: Path to the device private key.
 
-*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
+*Note: If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to generate new Certificate and Private Key while provisioning the device*
 
 #### Configuring the Fleet Provisioning feature via the command line
 ```
@@ -768,7 +768,7 @@ $ ./aws-iot-device-client --enable-fleet-provisioning [true|false] --fleet-provi
 }
 ```
 
-*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
+*Note: If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to generate new Certificate and Private Key while provisioning the device*
 
 
 ## Device Defender Feature

--- a/README.md
+++ b/README.md
@@ -558,9 +558,9 @@ More details about AWS IoT Fleet Provisioning by claim can be found here: https:
 
 *Note: If the fleet provisioning feature fails to provision the new key, certificate or thing/device, the device client will abort with fatal error.*
 
-*Note: If a CSR file is not provided, the Device Client will use Claim Certificate and Private key for provisioning the device.*
+*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
 
-*Note: Please make sure that the Claim certificate, private key and/or CSR file stored on device side have respective permissions applied to it as mentioned above in the "File and Directory Permissions" section of the readme.*
+*Note: Please make sure that the Claim certificate, private key and/or CSR file, device private key stored on device side have respective permissions applied to it as mentioned above in the "File and Directory Permissions" section of the readme.*
 
 Refer to the [CreateKeysAndCertificate](https://docs.aws.amazon.com/iot/latest/developerguide/fleet-provision-api.html#create-keys-cert) and [CreateCertificateFromCsr](https://docs.aws.amazon.com/iot/latest/developerguide/fleet-provision-api.html#create-cert-csr) APIs for more details.
 
@@ -571,6 +571,7 @@ The AWS IoT Device Client's Fleet Provisioning feature will require the followin
 * Claim Certificate
 * Private Key
 * CSR File (Required for creating certificate using [CreateCertificateFromCsr](https://docs.aws.amazon.com/iot/latest/developerguide/fleet-provision-api.html#create-cert-csr) API)
+* Device Private Key (Required for provisioning using CSR file)
 * Fleet Provisioning Template
 
 ### Sample Claim Certificate Policy
@@ -706,7 +707,7 @@ Once the device is provisioned correctly, Fleet Provisioning feature will valida
 The information stored in the runtime config file **created by Fleet Provisioning feature**:
 * Thing Name: Name of the newly provisioned thing
 * Certificate: Path of the newly created certificate file
-* Private Key: Path of the newly created private key file
+* Private Key: Path of the newly created or device private key file
 * FP Status: A boolean value stating if the Fleet Provision process was completed earlier. 
 
 The runtime-config file is stored on your device at ```~/.aws-iot-device-client/aws-iot-device-client-runtime.conf```.
@@ -720,7 +721,7 @@ Example runtime config created by Fleet Provisioning feature:
 "runtime-config": {
     "completed-fp": true,
     "cert": "/path/to/newly/created/certificate.pem.crt",
-    "key": "/path/to/newly/created/private.pem.key",
+    "key": "/path/to/private.pem.key",
     "thing-name": "NewlyProvisionedThingName"
     }
 }
@@ -742,11 +743,15 @@ To get started with the feature you will need to set the right configuration. Th
 
 **Optional Parameter:**
 
-`csr-file`: Path to the CSR file. If CSR file is not provided, the Device Client will use Private key and Claim certificate for provisioning the device
+`csr-file`: Path to the CSR file.
+
+`device-key`: Path to the device private key.
+
+*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
 
 #### Configuring the Fleet Provisioning feature via the command line
 ```
-$ ./aws-iot-device-client --enable-fleet-provisioning [true|false] --fleet-provisioning-template-name [Fleet-Provisioning-Template-Name] --csr-file [your/path/to/csr/file] 
+$ ./aws-iot-device-client --enable-fleet-provisioning [true|false] --fleet-provisioning-template-name [Fleet-Provisioning-Template-Name] --csr-file [your/path/to/csr/file] --device-key [your/path/to/device/private/key] 
 ```
 
 #### Configuring the Fleet Provisioning feature via the JSON configuration file
@@ -756,13 +761,14 @@ $ ./aws-iot-device-client --enable-fleet-provisioning [true|false] --fleet-provi
     "fleet-provisioning": {
         "enabled": [true|false],
         "template-name": "Fleet-Provisioning-Template-Name",
-        "csr-file": "your/path/to/csr/file"
+        "csr-file": "your/path/to/csr/file",
+        "device-key": "your/path/to/device/private/key"
     }
     ...
 }
 ```
 
-*Note: If CSR file is not provided, the Device Client will use Claim Certificate and Private key for provisioning the device.*
+*Note: If the CSR file or the Device Private Key is not provided, the Device Client will use Claim certificate and Private key for provisioning the device*
 
 
 ## Device Defender Feature

--- a/config-template.json
+++ b/config-template.json
@@ -23,6 +23,7 @@
 	"fleet-provisioning": {
 		"enabled": false,
 		"template-name": "replace_with_template_name",
-		"csr-file": "<replace_with_csr-file-path>"
+		"csr-file": "replace_with_csr_file_path",
+		"device-key": "replace_with_device_private_key_file_path"
 	}
 }

--- a/setup.sh
+++ b/setup.sh
@@ -128,6 +128,11 @@ if [ "$BUILD_CONFIG" = "y" ]; then
       if [ "$CSR_FILE_TEMP" ]; then
         FP_CSR_FILE=$CSR_FILE_TEMP
       fi
+      printf ${PMPT} "Specify absolute path to Device Private Key file:"
+      read -r DEVICE_KEY_TEMP
+      if [ "$DEVICE_KEY_TEMP" ]; then
+        FP_DEVICE_KEY=$DEVICE_KEY_TEMP
+      fi
     else
       FP_ENABLED="false"
     fi
@@ -158,7 +163,8 @@ if [ "$BUILD_CONFIG" = "y" ]; then
       \"fleet-provisioning\":	{
         \"enabled\":	$FP_ENABLED,
         \"template-name\": \"$FP_TEMPLATE_NAME\",
-        \"csr-file\": \"$FP_CSR_FILE\"
+        \"csr-file\": \"$FP_CSR_FILE\",
+        \"device-key\": \"$FP_DEVICE_KEY\"
       }
     }"
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1189,14 +1189,10 @@ void Config::PrintHelpMessage()
         "%s <csr-file-path>:\t\t\t\t\t\tUse specified CSR file to generate a certificate by keeping user private key "
         "secure. "
         "If the CSR file or the device key is not provided, Client will use Claim Certificate and Private key to "
-        "generate new "
-        "Certificate "
-        "and Private Key while provisioning the device\n"
+        "generate new Certificate and Private Key while provisioning the device\n"
         "%s <device-key-path>:\t\t\t\t\t\tUse specified device key after provisioning using csr file is completed"
         "If the CSR file or the device key is not provided, Client will use Claim Certificate and Private key to "
-        "generate new "
-        "Certificate "
-        "and Private Key while provisioning the device\n";
+        "generate new Certificate and Private Key while provisioning the device\n";
 
     cout << FormatMessage(
         helpMessageTemplate,

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1188,10 +1188,10 @@ void Config::PrintHelpMessage()
         "%s <template-name>:\t\t\tUse specified Fleet Provisioning template name\n"
         "%s <csr-file-path>:\t\t\t\t\t\tUse specified CSR file to generate a certificate by keeping user private key "
         "secure. "
-        "If the CSR file or the device key is not provided, Client will use Claim Certificate and Private key to "
+        "If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to "
         "generate new Certificate and Private Key while provisioning the device\n"
         "%s <device-key-path>:\t\t\t\t\t\tUse specified device key after provisioning using csr file is completed"
-        "If the CSR file or the device key is not provided, Client will use Claim Certificate and Private key to "
+        "If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to "
         "generate new Certificate and Private Key while provisioning the device\n";
 
     cout << FormatMessage(

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1187,12 +1187,12 @@ void Config::PrintHelpMessage()
         "%s <interval>:\t\t\t\t\tPositive integer to publish Device Defender metrics\n"
         "%s <template-name>:\t\t\tUse specified Fleet Provisioning template name\n"
         "%s <csr-file-path>:\t\t\t\t\t\tUse specified CSR file to generate a certificate by keeping user private key "
-        "secure. "
-        "If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to "
-        "generate new Certificate and Private Key while provisioning the device\n"
-        "%s <device-key-path>:\t\t\t\t\t\tUse specified device key after provisioning using csr file is completed"
-        "If the CSR file is specified without also specifying a device private key, the Device Client will use Claim Certificate and Private key to "
-        "generate new Certificate and Private Key while provisioning the device\n";
+        "secure. If the CSR file is specified without also specifying a device private key, the Device Client will use "
+        "Claim Certificate and Private key to generate new Certificate and Private Key while provisioning the device\n"
+        "%s <device-key-path>:\t\t\t\t\t\tUse specified device key to connect to IoT core after provisioning using csr "
+        "file is completed. If the CSR file is specified without also specifying a device private key, the Device "
+        "Client will use Claim Certificate and Private key to generate new Certificate and Private Key while "
+        "provisioning the device\n";
 
     cout << FormatMessage(
         helpMessageTemplate,

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -194,14 +194,17 @@ namespace Aws
                     static constexpr char CLI_ENABLE_FLEET_PROVISIONING[] = "--enable-fleet-provisioning";
                     static constexpr char CLI_FLEET_PROVISIONING_TEMPLATE_NAME[] = "--fleet-provisioning-template-name";
                     static constexpr char CLI_FLEET_PROVISIONING_CSR_FILE[] = "--csr-file";
+                    static constexpr char CLI_FLEET_PROVISIONING_DEVICE_KEY[] = "--device-key";
 
                     static constexpr char JSON_KEY_ENABLED[] = "enabled";
                     static constexpr char JSON_KEY_TEMPLATE_NAME[] = "template-name";
                     static constexpr char JSON_KEY_CSR_FILE[] = "csr-file";
+                    static constexpr char JSON_KEY_DEVICE_KEY[] = "device-key";
 
                     bool enabled{false};
                     Aws::Crt::Optional<std::string> templateName;
                     Aws::Crt::Optional<std::string> csrFile;
+                    Aws::Crt::Optional<std::string> deviceKey;
                 };
                 FleetProvisioning fleetProvisioning;
 

--- a/source/fleetprovisioning/FleetProvisioning.cpp
+++ b/source/fleetprovisioning/FleetProvisioning.cpp
@@ -563,10 +563,7 @@ bool FleetProvisioning::LocateDeviceKey(const string filePath)
     if (stat(expandedPath.c_str(), &info) != 0)
     {
         LOGM_ERROR(
-            TAG,
-            "*** %s: Failed to find the device private key %s, file does not exist ***",
-            DeviceClient::DC_FATAL_ERROR,
-            Sanitize(expandedPath).c_str());
+            TAG, "Failed to find the device private key %s, file does not exist", Sanitize(expandedPath).c_str());
         locatedDeviceKey = false;
     }
     else

--- a/source/fleetprovisioning/FleetProvisioning.h
+++ b/source/fleetprovisioning/FleetProvisioning.h
@@ -178,6 +178,14 @@ namespace Aws
                      * @return returns false if client is not able to open the file or if file is empty
                      */
                     bool GetCsrFileContent(const std::string filePath);
+
+                    /**
+                     * \brief locate and validate device private key
+                     *
+                     * @param filePath Device private key location
+                     * @return returns false if client is not able to find the file or if valid permissions are not set
+                     */
+                    bool LocateDeviceKey(const std::string filePath);
                 };
             } // namespace FleetProvisioningNS
         }     // namespace DeviceClient

--- a/source/fleetprovisioning/FleetProvisioning.h
+++ b/source/fleetprovisioning/FleetProvisioning.h
@@ -182,7 +182,7 @@ namespace Aws
                     /**
                      * \brief locate and validate device private key
                      *
-                     * @param filePath Device private key location
+                     * @param filePath device private key location
                      * @return returns false if client is not able to find the file or if valid permissions are not set
                      */
                     bool LocateDeviceKey(const std::string filePath);

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -407,8 +407,14 @@ TEST(Config, MissingFleetProvisioningConfig)
 
     config.LoadFromCliArgs(cliArgs);
 
+#if !defined(DISABLE_MQTT)
+    // ST_COMPONENT_MODE does not require any settings besides those for Secure Tunneling
     ASSERT_FALSE(config.Validate());
     ASSERT_TRUE(config.fleetProvisioning.enabled);
+#else
+    ASSERT_TRUE(config.Validate());
+    ASSERT_FALSE(config.fleetProvisioning.enabled);
+#endif
 }
 
 TEST(Config, FleetProvisioningCli)

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -413,7 +413,6 @@ TEST(Config, MissingFleetProvisioningConfig)
     ASSERT_TRUE(config.fleetProvisioning.enabled);
 #else
     ASSERT_TRUE(config.Validate());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
 #endif
 }
 

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -33,6 +33,12 @@ TEST(Config, AllFeaturesEnabled)
     "device-defender": {
         "enabled": true,
         "interval": 300
+    },
+    "fleet-provisioning": {
+        "enabled": true,
+        "template-name": "template-name",
+		"csr-file": "csr-file",
+		"device-key": "device-key"
     }
 })";
     JsonObject jsonObject(jsonString);
@@ -53,7 +59,11 @@ TEST(Config, AllFeaturesEnabled)
     ASSERT_TRUE(config.jobs.enabled);
     ASSERT_TRUE(config.tunneling.enabled);
     ASSERT_TRUE(config.deviceDefender.enabled);
+    ASSERT_TRUE(config.fleetProvisioning.enabled);
     ASSERT_EQ(300, config.deviceDefender.interval);
+    ASSERT_STREQ("template-name", config.fleetProvisioning.templateName->c_str());
+    ASSERT_STREQ("csr-file", config.fleetProvisioning.csrFile->c_str());
+    ASSERT_STREQ("device-key", config.fleetProvisioning.deviceKey->c_str());
 }
 
 TEST(Config, HappyCaseMinimumConfig)
@@ -347,4 +357,91 @@ TEST(Config, SDKLoggingConfigurationJson)
     ASSERT_EQ(3, config.logConfig.deviceClientlogLevel);
     ASSERT_STREQ("stdout", config.logConfig.deviceClientLogtype.c_str());
     ASSERT_STREQ("device-client.log", config.logConfig.deviceClientLogFile.c_str());
+}
+
+TEST(Config, FleetProvisioningMinimumConfig)
+{
+    constexpr char jsonString[] = R"(
+{
+	"endpoint": "endpoint value",
+	"cert": "cert",
+	"key": "key",
+	"root-ca": "root-ca",
+	"thing-name": "thing-name value",
+    "fleet-provisioning": {
+        "enabled": true,
+        "template-name": "template-name"
+    }
+})";
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    ASSERT_TRUE(config.Validate());
+    ASSERT_TRUE(config.fleetProvisioning.enabled);
+    ASSERT_STREQ("template-name", config.fleetProvisioning.templateName->c_str());
+}
+
+TEST(Config, MissingFleetProvisioningConfig)
+{
+    constexpr char jsonString[] = R"(
+{
+	"endpoint": "endpoint value",
+	"cert": "cert",
+	"key": "key",
+	"root-ca": "root-ca",
+	"thing-name": "thing-name value"
+})";
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    CliArgs cliArgs;
+    cliArgs[PlainConfig::FleetProvisioning::CLI_ENABLE_FLEET_PROVISIONING] = "true";
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    ASSERT_TRUE(config.Validate());
+
+    config.LoadFromCliArgs(cliArgs);
+
+    ASSERT_FALSE(config.Validate());
+    ASSERT_TRUE(config.fleetProvisioning.enabled);
+}
+
+TEST(Config, FleetProvisioningCli)
+{
+    constexpr char jsonString[] = R"(
+{
+	"endpoint": "endpoint value",
+	"cert": "cert",
+	"key": "key",
+	"root-ca": "root-ca",
+	"thing-name": "thing-name value",
+    "fleet-provisioning": {
+        "enabled": true,
+        "template-name": "template-name",
+		"csr-file": "csr-file",
+		"device-key": "device-key"
+    }
+})";
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    CliArgs cliArgs;
+    cliArgs[PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_TEMPLATE_NAME] = "cli-template-name";
+    cliArgs[PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_CSR_FILE] = "cli-csr-file";
+    cliArgs[PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_DEVICE_KEY] = "cli-device-key";
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+    config.LoadFromCliArgs(cliArgs);
+
+    ASSERT_TRUE(config.Validate());
+    ASSERT_TRUE(config.fleetProvisioning.enabled);
+    ASSERT_STREQ("cli-template-name", config.fleetProvisioning.templateName->c_str());
+    ASSERT_STREQ("cli-csr-file", config.fleetProvisioning.csrFile->c_str());
+    ASSERT_STREQ("cli-device-key", config.fleetProvisioning.deviceKey->c_str());
 }


### PR DESCRIPTION

*Issue #101*

*Description of changes:*
With this commit, I am adding config option for user to provide the device private key location via CLI or JSON file. This option will be required for provisioning the device using CSR file (CreateCertificateFromCsr API). If the device key or the CSR file is not provided, Device Client will use claim certificate and bootstrap private key (CreateKeysAndCertificate API) for provisioning the device.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
