### PR TITLE
Add CodeDeploy config for integration test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}"                                                                                                                          
           path: |                                                                                                                                                                                             
             ./build/${{ env.PACKAGE_NAME }}
+            ./setup/
   
   update-doxygen:
     runs-on: ubuntu-latest
@@ -79,6 +80,7 @@ jobs:
           name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}"                                                                                                                          
           path: |                                                                                                                                                                                             
             ./build/${{ env.PACKAGE_NAME }}
+            ./setup/
 
   build-mips32:
     runs-on: ubuntu-latest
@@ -101,6 +103,7 @@ jobs:
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}"                                                                                                                          
           path: |                                                                                                                                                                                             
             ./build/${{ env.PACKAGE_NAME }}
+            ./setup/
 
   build-aarch64:
     runs-on: ubuntu-latest
@@ -123,6 +126,7 @@ jobs:
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}"                                                                                                                          
           path: |                                                                                                                                                                                             
             ./build/${{ env.PACKAGE_NAME }}
+            ./setup/
 
   build-amazonlinux:
     runs-on: ubuntu-latest
@@ -157,6 +161,7 @@ jobs:
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}"                                                                                                                          
           path: |                                                                                                                                                                                             
             ./build/${{ env.PACKAGE_NAME }}
+            ./setup/
 
   gpp-compat:
     runs-on: ubuntu-latest

--- a/setup/appspec.yml
+++ b/setup/appspec.yml
@@ -1,0 +1,14 @@
+version: 0.0
+os: linux
+files:
+  - source: /aws-iot-device-client
+    destination: /sbin/
+hooks:
+  ApplicationStart:
+    - location: codedeploy/start_service.sh
+      timeout: 300
+      runas: root
+  ApplicationStop:
+    - location: codedeploy/stop_service.sh
+      timeout: 300
+      runas: root

--- a/setup/codedeploy/start_service.sh
+++ b/setup/codedeploy/start_service.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chmod +x /sbin/aws-iot-device-client
+systemctl start aws-iot-device-client.service

--- a/setup/codedeploy/stop_service.sh
+++ b/setup/codedeploy/stop_service.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+systemctl stop aws-iot-device-client.service


### PR DESCRIPTION
This commit adds support for including CodeDeploy configuration files in device client archives to enable automated deployment to our integration test machines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
