### PR TITLE
Fix for build failing due to permissions.  Removing unnessary build files

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -130,6 +130,8 @@ case $compileMode in
     elif [ "$sharedLibs" = true ]; then
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake -DBUILD_SDK=ON ../ || true
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake -DBUILD_SDK=ON ../
+      make install DESTDIR=./shared_install_dir
+      chmod 0777 ./shared_install_dir
     else
       # Fix for the Cmake executing build of the sdk which errors out linking incorrectly to openssl
       cmake -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake ../ || true
@@ -162,6 +164,8 @@ case $compileMode in
     if [ "$sharedLibs" = true ]; then
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-mips.cmake ../ || true
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-mips.cmake ../
+      make install DESTDIR=./shared_install_dir
+      chmod 0777 ./shared_install_dir
     else
       cmake -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-mips.cmake ../ || true
       cmake -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-mips.cmake ../
@@ -197,6 +201,8 @@ case $compileMode in
     elif [ "$sharedLibs" = true ]; then
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake -DBUILD_SDK=ON ../ || true
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake -DBUILD_SDK=ON ../
+      make install DESTDIR=./shared_install_dir
+      chmod 0777 ./shared_install_dir
     else
       # Fix for the Cmake executing build of the sdk which errors out linking incorrectly to openssl
       cmake -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake ../ || true
@@ -210,7 +216,9 @@ case $compileMode in
     if [ "$sharedLibs" = false ]; then
       cmake ../ -DBUILD_SDK=OFF -DBUILD_TEST_DEPS=OFF -DLINK_DL=ON
     else
-      cmake ../ -DBUILD_SHARED_LIBS=ON -DBUILD_SDK=ON -DBUILD_TEST_DEPS=OFF -DLINK_DL=ON
+      cmake ../ -DBUILD_SHARED_LIBS=ON -DBUILD_SDK=ON -DLINK_DL=ON
+      make install DESTDIR=./shared_install_dir
+      chmod 0777 ./shared_install_dir
     fi
     ;;
 esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,8 @@ jobs:
         with:                                                                                                                                                                                                 
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.shared"                                                                                                                          
           path: |                                                                                                                                                                                             
-            ./build/
+            ./build/${{ env.PACKAGE_NAME }}
+            ./build/shared_install_dir
             ./setup/
   
   build-shared-libs-amazonlinux:
@@ -232,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 0      
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
@@ -246,7 +247,8 @@ jobs:
         with:                                                                                                                                                                                                 
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}.shared"
           path: |                                                                                                                                                                                             
-            ./build/
+            ./build/${{ env.PACKAGE_NAME }}
+            ./build/shared_install_dir
             ./setup/
 
   build-shared-libs-armhf32:
@@ -261,6 +263,7 @@ jobs:
             export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
             docker pull $DOCKER_IMAGE
             docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=armhf_cross_mode_shared_libs
+        
         - name: Archive armhf32 Build Artifact                                                                                                                                                        
           uses: actions/upload-artifact@v2                                                                                                                                                                      
           # Run for main branch only                                                                                                                                                                            
@@ -268,7 +271,8 @@ jobs:
           with:                                                                                                                                                                                                 
             name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}.shared"
             path: |                                                                                                                                                                                             
-              ./build/
+              ./build/${{ env.PACKAGE_NAME }}
+              ./build/shared_install_dir
               ./setup/
 
   build-shared-libs-mips32:
@@ -290,7 +294,8 @@ jobs:
         with:                                                                                                                                                                                                 
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}.shared"
           path: |                                                                                                                                                                                             
-            ./build/
+            ./build/${{ env.PACKAGE_NAME }}
+            ./build/shared_install_dir
             ./setup/
 
   build-shared-libs-aarch64:
@@ -312,7 +317,8 @@ jobs:
         with:                                                                                                                                                                                                 
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}.shared"
           path: |                                                                                                                                                                                             
-            ./build/
+            ./build/${{ env.PACKAGE_NAME }}
+            ./build/shared_install_dir
             ./setup/
 
   build-st-ubuntu-16-x64:


### PR DESCRIPTION
*Description of changes:*
Build was failing due to files being created in the build folder with different permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
