### PR TITLE
Added notice about charges to README, moved aws_http_library_init to sharedCRTResourceManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # AWS IoT Device Client
 
+ **Notice:** Running the AWS IoT Device Client will incur usage of AWS IoT services, and is likely to incur charges on your AWS account. Please refer the pricing pages for [AWS IoT Core](https://aws.amazon.com/iot-core/pricing/), [AWS IoT Device Management](https://aws.amazon.com/iot-device-management/pricing/), and [AWS IoT Device Defender](https://aws.amazon.com/iot-device-defender/pricing/) for more details.
+
 - [AWS IoT Device Client](#aws-iot-device-client)
   * [Introduction](#introduction)
     + [Current Capabilities](#current-capabilities)

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -136,6 +136,22 @@ int SharedCrtResourceManager::buildClient(const PlainConfig &config)
     return SharedCrtResourceManager::SUCCESS;
 }
 
+void SharedCrtResourceManager::initializeAWSHttpLib()
+{
+    if (!initialized)
+    {
+        LOG_WARN(TAG, "Tried to aws_http_library_init but the SharedCrtResourceManager has not yet been initialized!");
+        return;
+    }
+    if (initializedAWSHttpLib)
+    {
+        LOG_WARN(TAG, "Tried to aws_http_library_init but it was already initialized!");
+        return;
+    }
+    aws_http_library_init(getAllocator());
+    initializedAWSHttpLib = true;
+}
+
 int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
 {
     if (!locateCredentials(config))

--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -6,6 +6,7 @@
 
 #include "config/Config.h"
 
+#include <atomic>
 #include <aws/crt/Api.h>
 #include <aws/iot/MqttClient.h>
 #include <iostream>
@@ -29,6 +30,7 @@ namespace Aws
 
                 static constexpr int DEFAULT_WAIT_TIME_SECONDS = 10;
                 bool initialized = false;
+                std::atomic<bool> initializedAWSHttpLib{false};
                 std::promise<void> connectionClosedPromise;
                 std::unique_ptr<Aws::Crt::ApiHandle> apiHandle;
                 std::unique_ptr<Aws::Crt::Io::EventLoopGroup> eventLoopGroup;
@@ -47,6 +49,7 @@ namespace Aws
                 static const int RETRY = 1;
                 static const int ABORT = 2;
                 bool initialize(const PlainConfig &config);
+                void initializeAWSHttpLib();
                 int establishConnection(const PlainConfig &config);
                 std::shared_ptr<Crt::Mqtt::MqttConnection> getConnection();
                 Aws::Crt::Io::EventLoopGroup *getEventLoopGroup();

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -38,8 +38,7 @@ namespace Aws
                     shared_ptr<ClientBaseNotifier> notifier,
                     const PlainConfig &config)
                 {
-                    // TODO: UA-5774 - Move SDK initialization to application level
-                    aws_http_library_init(sharedCrtResourceManager->getAllocator());
+                    sharedCrtResourceManager->initializeAWSHttpLib();
 
                     this->mSharedCrtResourceManager = sharedCrtResourceManager;
                     mDeviceApiHandle = unique_ptr<Aws::Iotdevicecommon::DeviceApiHandle>(


### PR DESCRIPTION
*Description of changes:*
* Added Notice about charges incurred to Readme
* Moved aws_http_library_init to sharedCRTResourceManager

There is on reason to call aws_http_library_init if multiple features
require this especially when dealing with feature compilation.
It should be handled by the sharedCRTResourceManager where we can ignore
additional calls to initialize it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
