### PR TITLE
Add artifact removal configuration for integration tests

### DIFF
--- a/setup/appspec.yml
+++ b/setup/appspec.yml
@@ -4,6 +4,10 @@ files:
   - source: /aws-iot-device-client
     destination: /sbin/
 hooks:
+  BeforeInstall:
+    - location: codedeploy/before_install.sh
+      timeout: 300
+      runas: root
   ApplicationStart:
     - location: codedeploy/start_service.sh
       timeout: 300

--- a/setup/codedeploy/before_install.sh
+++ b/setup/codedeploy/before_install.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm /sbin/aws-iot-device-client


### PR DESCRIPTION
This commit adds a before_install step to our CodeDeploy configuration to enable deletion of existing artifacts from the /sbin folder of our integration test machines. Our CodeDeploy deployments are currently failing without this change, since the artifact already exists when we attempt to deploy the new one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
