### PR TITLE
Added logic to run on pull_request and push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '*'
+  pull_request:
+    branches:
+      - '*'
 
 env:
   PACKAGE_NAME: aws-iot-device-client
@@ -11,7 +14,7 @@ env:
 jobs:
   update-doxygen:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  
+    if: ((github.event_name == 'push') && (github.ref == 'refs/heads/main'))
     steps:
     - uses: actions/checkout@v2
       with:
@@ -39,6 +42,7 @@ jobs:
 
   build-ubuntu-16-x64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -68,6 +72,7 @@ jobs:
 
   build-amazonlinux:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -81,6 +86,7 @@ jobs:
   
   build-rhel-ubi8:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -110,6 +116,7 @@ jobs:
 
   gpp-compat:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     strategy:
       matrix:
         version: [ 5,6,7,8 ]
@@ -126,6 +133,7 @@ jobs:
 
   clangpp-compat:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     strategy:
       matrix:
         version: [ 5.0, 6.0, 7, 8, 9 ]
@@ -142,6 +150,7 @@ jobs:
 
   build-armhf32:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -171,6 +180,7 @@ jobs:
 
   build-mips32:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -200,6 +210,7 @@ jobs:
 
   build-aarch64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -229,6 +240,7 @@ jobs:
 
   build-shared-libs-ubuntu-16-x64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -266,6 +278,7 @@ jobs:
   
   build-shared-libs-amazonlinux:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -279,6 +292,7 @@ jobs:
 
   build-shared-libs-rhel-ubi8:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -316,6 +330,7 @@ jobs:
 
   build-shared-libs-armhf32:
       runs-on: ubuntu-latest
+      if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
       steps:
         - uses: actions/checkout@v2
           with:
@@ -353,6 +368,7 @@ jobs:
 
   build-shared-libs-mips32:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -390,6 +406,7 @@ jobs:
 
   build-shared-libs-aarch64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -427,6 +444,7 @@ jobs:
 
   build-st-ubuntu-16-x64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -448,6 +466,7 @@ jobs:
 
   build-st-ubuntu-16-aarch64:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:
@@ -469,6 +488,7 @@ jobs:
 
   build-st-ubuntu-16-armhf32:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,17 @@
 name: Lint
 
-on: [push]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   clang-format:
-
     runs-on: ubuntu-latest
-
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
     - name: Checkout Sources
       uses: actions/checkout@v1


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
Added logic to run on pull_request and push, but to skip test instead of running double when not forked


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 
Run actions on PR if forked, and skip if NOT forked

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
CI test run result: 
https://github.com/awslabs/aws-iot-device-client/actions/runs/746478459
https://github.com/awslabs/aws-iot-device-client/actions/runs/746459219


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
