### PR TITLE
Resolved issue where pub sub sample lost reference on the Default Publish Payload allocator, publishing a blank string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Resolved issue where missing pub sub sample files (publish file and subscribe file) would cause a seg fault
+- Resolved issue where pub sub sample lost reference on the Default Publish Payload allocator, publishing a blank string
 
 ## [1.1.X] - 2021-04-14
 ### Added


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
Problem identified by @matthewpaul 


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 
We have a default payload, if a "data input file" isn't provided.  when the publish actions was "retriggered"  the lambda function would lose reference on the default allocator causing it to publish a blank string

This is solved by using our sharedCRT allocator instead of the default one

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
Tested with IoT MQTT Client


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
