### PR TITLE
Updated LoadFromJson function for pubsub sample to resolve seg fault

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -1,9 +1,9 @@
 {
-	"endpoint": "replace_with_endpoint_value",
-	"cert": "replace_with_certificate_file_location",
-	"key": "replace_with_private_key_file_location",
-	"root-ca": "replace_with_root_ca_file_location",
-	"thing-name": "replace_with_thing_name",
+	"endpoint": "<replace_with_endpoint_value>",
+	"cert": "<replace_with_certificate_file_path>",
+	"key": "<replace_with_private_key_file_path>",
+	"root-ca": "<replace_with_root_ca_file_path>",
+	"thing-name": "<replace_with_thing_name>",
 	"logging": {
 		"level": "DEBUG",
 		"type": "FILE",
@@ -11,28 +11,28 @@
 	},
 	"jobs": {
 		"enabled": true,
-		"handler-directory": "replace_with_path_to_handler_dir"
+		"handler-directory": "<replace_with_job_handler_directory_path>"
 	},
 	"tunneling": {
 		"enabled": true
 	},
-	"device-defender":	{
+	"device-defender": {
 		"enabled": true,
 		"interval": 300
 	},
 	"fleet-provisioning": {
 		"enabled": false,
-		"template-name": "replace_with_template_name",
-		"csr-file": "replace_with_csr_file_path",
-		"device-key": "replace_with_device_private_key_file_path"
+		"template-name": "<replace_with_template_name>",
+		"csr-file": "<replace_with_csr_file_path>",
+		"device-key": "<replace_with_device_private_key_file_path>"
 	},
 	"samples": {
 		"pub-sub": {
 			"enabled": false,
-			"publish-topic": "replace_with_publish_topic",
-			"publish-file": "replace_with_publish_file",
-			"subscribe-topic": "replace_with_subscribe_topic",
-			"subscribe-file": "replace_with_subscribe_file"
+			"publish-topic": "<replace_with_publish_topic>",
+			"publish-file": "<replace_with_publish_file_path>",
+			"subscribe-topic": "<replace_with_subscribe_topic>",
+			"subscribe-file": "<replace_with_subscribe_file_path>"
 		}
 	}
 }

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1044,10 +1044,6 @@ bool PlainConfig::PubSub::Validate() const
     {
         if (!FileUtils::ValidateFilePermissions(publishFile.value(), Permissions::PUB_SUB_FILES, true))
         {
-            LOGM_ERROR(
-                Config::TAG,
-                "*** %s: Publish File field must be specified if Pub-Sub sample feature is enabled ***",
-                DeviceClient::DC_FATAL_ERROR);
             return false;
         }
     }
@@ -1063,10 +1059,6 @@ bool PlainConfig::PubSub::Validate() const
     {
         if (!FileUtils::ValidateFilePermissions(subscribeFile.value(), Permissions::PUB_SUB_FILES, true))
         {
-            LOGM_ERROR(
-                Config::TAG,
-                "*** %s: Subscribe File field must be specified if Pub-Sub sample feature is enabled ***",
-                DeviceClient::DC_FATAL_ERROR);
             return false;
         }
     }

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -949,25 +949,53 @@ bool PlainConfig::PubSub::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_PUB_SUB_PUBLISH_TOPIC;
     if (json.ValueExists(jsonKey))
     {
-        publishTopic = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        if (!json.GetString(jsonKey).empty())
+        {
+            publishTopic = json.GetString(jsonKey).c_str();
+        }
+        else
+        {
+            LOGM_WARN(Config::TAG, "Key {%s} was provided in the JSON configuration file with an empty value", jsonKey);
+        }
     }
 
     jsonKey = JSON_PUB_SUB_PUBLISH_FILE;
     if (json.ValueExists(jsonKey))
     {
-        publishFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        if (!json.GetString(jsonKey).empty())
+        {
+            publishFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        }
+        else
+        {
+            LOGM_WARN(Config::TAG, "Key {%s} was provided in the JSON configuration file with an empty value", jsonKey);
+        }
     }
 
     jsonKey = JSON_PUB_SUB_SUBSCRIBE_TOPIC;
     if (json.ValueExists(jsonKey))
     {
-        subscribeTopic = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        if (!json.GetString(jsonKey).empty())
+        {
+            subscribeTopic = json.GetString(jsonKey).c_str();
+        }
+        else
+        {
+            LOGM_WARN(Config::TAG, "Key {%s} was provided in the JSON configuration file with an empty value", jsonKey);
+        }
     }
 
     jsonKey = JSON_PUB_SUB_SUBSCRIBE_FILE;
     if (json.ValueExists(jsonKey))
     {
-        subscribeFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        if (!json.GetString(jsonKey).empty())
+        {
+            subscribeFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        }
+        else
+        {
+            LOGM_WARN(Config::TAG, "Key {%s} was provided in the JSON configuration file with an empty value", jsonKey);
+        }
     }
 
     return true;
@@ -1012,6 +1040,17 @@ bool PlainConfig::PubSub::Validate() const
             DeviceClient::DC_FATAL_ERROR);
         return false;
     }
+    if (publishFile.has_value() && !publishFile->empty())
+    {
+        if (!FileUtils::ValidateFilePermissions(publishFile.value(), Permissions::PUB_SUB_FILES, true))
+        {
+            LOGM_ERROR(
+                Config::TAG,
+                "*** %s: Publish File field must be specified if Pub-Sub sample feature is enabled ***",
+                DeviceClient::DC_FATAL_ERROR);
+            return false;
+        }
+    }
     if (!subscribeTopic.has_value() || subscribeTopic->empty())
     {
         LOGM_ERROR(
@@ -1020,17 +1059,14 @@ bool PlainConfig::PubSub::Validate() const
             DeviceClient::DC_FATAL_ERROR);
         return false;
     }
-    if (publishFile.has_value() && !publishFile->empty())
-    {
-        if (!FileUtils::ValidateFilePermissions(publishFile.value(), Permissions::PUB_SUB_FILES, true))
-        {
-            return false;
-        }
-    }
     if (subscribeFile.has_value() && !subscribeFile->empty())
     {
         if (!FileUtils::ValidateFilePermissions(subscribeFile.value(), Permissions::PUB_SUB_FILES, true))
         {
+            LOGM_ERROR(
+                Config::TAG,
+                "*** %s: Subscribe File field must be specified if Pub-Sub sample feature is enabled ***",
+                DeviceClient::DC_FATAL_ERROR);
             return false;
         }
     }
@@ -1377,8 +1413,13 @@ bool Config::ExportDefaultSetting(const string &file)
     "%s": "<replace_with_root_ca_file_path>",
     "%s": "<replace_with_thing_name>",
     "%s": {
+        "%s": "DEBUG",
+        "%s": "FILE",
+        "%s": "/var/log/aws-iot-device-client/aws-iot-device-client.log"
+    },
+    "%s": {
         "%s": true,
-        "%s": "<replace_with_job_handler-directory_path>"
+        "%s": "<replace_with_job_handler_directory_path>"
     },
     "%s": {
         "%s": true
@@ -1386,11 +1427,21 @@ bool Config::ExportDefaultSetting(const string &file)
     "%s": {
         "%s": true,
         "%s": <replace_with_interval>
-    }
+    },
     "%s": {
-        "%s": true,
+        "%s": false,
         "%s": "<replace_with_template_name>",
-        "%s": "<replace_with_csr-file-path>"
+        "%s": "<replace_with_csr_file_path>",
+        "%s": "<replace_with_device_private_key_file_path>"
+    },
+    "%s": {
+        "%s": {
+            "%s": false,
+            "%s": "<replace_with_publish_topic>",
+            "%s": "<replace_with_publish_file_path>",
+            "%s": "<replace_with_subscribe_topic>",
+            "%s": "<replace_with_subscribe_file_path>"
+        }
     }
 }
 )";
@@ -1407,6 +1458,10 @@ bool Config::ExportDefaultSetting(const string &file)
         PlainConfig::JSON_KEY_KEY,
         PlainConfig::JSON_KEY_ROOT_CA,
         PlainConfig::JSON_KEY_THING_NAME,
+        PlainConfig::JSON_KEY_LOGGING,
+        PlainConfig::LogConfig::JSON_KEY_LOG_LEVEL,
+        PlainConfig::LogConfig::JSON_KEY_LOG_TYPE,
+        PlainConfig::LogConfig::JSON_KEY_LOG_FILE,
         PlainConfig::JSON_KEY_JOBS,
         PlainConfig::Jobs::JSON_KEY_ENABLED,
         PlainConfig::Jobs::JSON_KEY_HANDLER_DIR,
@@ -1418,7 +1473,15 @@ bool Config::ExportDefaultSetting(const string &file)
         PlainConfig::JSON_KEY_FLEET_PROVISIONING,
         PlainConfig::FleetProvisioning::JSON_KEY_ENABLED,
         PlainConfig::FleetProvisioning::JSON_KEY_TEMPLATE_NAME,
-        PlainConfig::FleetProvisioning::JSON_KEY_CSR_FILE);
+        PlainConfig::FleetProvisioning::JSON_KEY_CSR_FILE,
+        PlainConfig::FleetProvisioning::JSON_KEY_DEVICE_KEY,
+        PlainConfig::JSON_KEY_SAMPLES,
+        PlainConfig::JSON_KEY_PUB_SUB,
+        PlainConfig::PubSub::JSON_ENABLE_PUB_SUB,
+        PlainConfig::PubSub::JSON_PUB_SUB_PUBLISH_TOPIC,
+        PlainConfig::PubSub::JSON_PUB_SUB_PUBLISH_FILE,
+        PlainConfig::PubSub::JSON_PUB_SUB_SUBSCRIBE_TOPIC,
+        PlainConfig::PubSub::JSON_PUB_SUB_SUBSCRIBE_FILE);
 
     clientConfig.close();
     LOGM_INFO(TAG, "Exported settings to: %s", Sanitize(file).c_str());


### PR DESCRIPTION
### Motivation
- With Pub-Sub sample disabled and config items with empty value in the pub-sub block, the DC application was failing to start with and segmentation fault. 
- ExportDefaultSetting method was not updated with our default config file provided to our customers. 

```
./aws-iot-device-client 
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted (core dumped)
```

### Modifications
#### Change summary
- Updated LoadFromJson function for pub-sub sample to resolve segmentation fault 
- Updated ExportDefaultSetting to sync with our default 'config-template.json' file. Added configs for Logger and FP.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

- Removed Error Logs from validation method to avoid confusion as asked.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 This change is tested and verified manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
