### PR TITLE
fix the high cpu utilization issue caused by infinite while loop in StdoutLogger

### DIFF
--- a/source/logging/StdOutLogger.cpp
+++ b/source/logging/StdOutLogger.cpp
@@ -31,6 +31,7 @@ void StdOutLogger::run()
         {
             writeLogMessage(std::move(message));
         }
+        this_thread::sleep_for(std::chrono::milliseconds(25));
     }
 }
 

--- a/source/logging/StdOutLogger.cpp
+++ b/source/logging/StdOutLogger.cpp
@@ -12,6 +12,8 @@
 using namespace std;
 using namespace Aws::Iot::DeviceClient::Logging;
 
+constexpr int StdOutLogger::DEFAULT_WAIT_TIME_MILLISECONDS;
+
 void StdOutLogger::writeLogMessage(unique_ptr<LogMessage> message)
 {
     char time_buffer[TIMESTAMP_BUFFER_SIZE];
@@ -31,7 +33,7 @@ void StdOutLogger::run()
         {
             writeLogMessage(std::move(message));
         }
-        this_thread::sleep_for(std::chrono::milliseconds(25));
+        this_thread::sleep_for(std::chrono::milliseconds(DEFAULT_WAIT_TIME_MILLISECONDS));
     }
 }
 

--- a/source/logging/StdOutLogger.h
+++ b/source/logging/StdOutLogger.h
@@ -30,7 +30,8 @@ namespace Aws
                      */
                     bool needsShutdown = false;
                     /**
-                     * \brief The default value in milliseconds for which Device client will wait after getting a log message from logQueue
+                     * \brief The default value in milliseconds for which Device client will wait after getting a
+                     * log message from logQueue
                      */
                     static constexpr int DEFAULT_WAIT_TIME_MILLISECONDS = 1;
                     /**

--- a/source/logging/StdOutLogger.h
+++ b/source/logging/StdOutLogger.h
@@ -30,6 +30,10 @@ namespace Aws
                      */
                     bool needsShutdown = false;
                     /**
+                     * \brief The default value in milliseconds for which Device client will wait after getting a log message from logQueue
+                     */
+                    static constexpr int DEFAULT_WAIT_TIME_MILLISECONDS = 1;
+                    /**
                      * \brief a LogQueue instance used to queue incoming log messages for processing
                      */
                     std::unique_ptr<LogQueue> logQueue = std::unique_ptr<LogQueue>(new LogQueue);


### PR DESCRIPTION
### Motivation
- We found the issue that it will take almost 99% of CPU when device client is running, this change is going to fix this by adding sleep time in an infinite while loop we use in StdoutLogger. 
- Issue number:  https://github.com/awslabs/aws-iot-device-client/issues/14



### Modifications
#### Change summary
This a one-line change to make logger thread sleep 25ms after every time we fetch a log message from log queue

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  I've tested this change on my personal testing machines and I verified that CPU utilization would be down to 1% after I add sleep time


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
