### PR TITLE
Another fix of the high cpu utilization issue caused by infinite while loop in FileLogger

### DIFF
--- a/source/logging/FileLogger.cpp
+++ b/source/logging/FileLogger.cpp
@@ -14,6 +14,8 @@ using namespace std;
 using namespace Aws::Iot::DeviceClient::Logging;
 using namespace Aws::Iot::DeviceClient::Util;
 
+constexpr int FileLogger::DEFAULT_WAIT_TIME_MILLISECONDS;
+
 bool FileLogger::start(const PlainConfig &config)
 {
     setLogLevel(config.logConfig.deviceClientlogLevel);
@@ -113,6 +115,7 @@ void FileLogger::run()
         {
             writeLogMessage(std::move(message));
         }
+        this_thread::sleep_for(std::chrono::milliseconds(DEFAULT_WAIT_TIME_MILLISECONDS));
     }
 }
 

--- a/source/logging/FileLogger.h
+++ b/source/logging/FileLogger.h
@@ -41,6 +41,12 @@ namespace Aws
                     std::string logFile = DEFAULT_LOG_FILE;
 
                     /**
+                     * \brief The default value in milliseconds for which Device client will wait after getting a
+                     * log message from logQueue
+                     */
+                    static constexpr int DEFAULT_WAIT_TIME_MILLISECONDS = 1;
+
+                    /**
                      * \brief Flag used to notify underlying threads that they should discontinue any processing
                      * so that the application can safely shutdown
                      */


### PR DESCRIPTION


### Motivation
- We found the issue that it will take almost 99% of CPU when device client is running, I had made a change on StdLogger file but this change is going to fix this by adding sleep time in an infinite while loop we use in FileLogger
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/147


### Modifications
#### Change summary
This a one-line change to make logger thread sleep 1ms after every time we fetch a log message from log queue

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason. I've tested this change on my personal testing machines by running DC as service with FileLogger enabled and I verified that CPU utilization would be down to 1% after I add sleep time
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
