### PR TITLE
Pass Device Client Telemetry data to SDK to log connection calls comming from Device Client

### DIFF
--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -165,6 +165,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     auto clientConfigBuilder = MqttClientConnectionConfigBuilder(config.cert->c_str(), config.key->c_str());
     clientConfigBuilder.WithEndpoint(config.endpoint->c_str());
     clientConfigBuilder.WithCertificateAuthority(config.rootCa->c_str());
+    clientConfigBuilder.WithSdkName(SharedCrtResourceManager::BINARY_NAME);
+    clientConfigBuilder.WithSdkVersion(SharedCrtResourceManager::BINARY_VERSION);
     auto clientConfig = clientConfigBuilder.Build();
 
     if (!clientConfig)

--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -27,6 +27,8 @@ namespace Aws
             {
               private:
                 const char *TAG = "SharedCrtResourceManager.cpp";
+                const char *BINARY_NAME = "IoTDeviceClient";
+                const char *BINARY_VERSION = "1.2";
 
                 static constexpr int DEFAULT_WAIT_TIME_SECONDS = 10;
                 bool initialized = false;


### PR DESCRIPTION
### Motivation
- This change is made to add support for logging connection calls coming from Device Client. Before this we were logging SDK calls only.


### Modifications
#### Change summary
- Passed Device Client version and binary name to SDK to log calls coming from Device Client.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
