### PR TITLE
Move git submodule update after checkout in docker build

### DIFF
--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -22,11 +22,11 @@ RUN yum -y update \
 WORKDIR /tmp
 RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
     && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \ 
+    && cd cmake-3.10.0 \
     && ./bootstrap \
     && make -j 4 \
     && make install
-    
+
 ###############################################################################
 # Install OpenSSL 1.1.1
 ###############################################################################
@@ -58,11 +58,13 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
 WORKDIR /home/aws-iot-device-client
 RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
-    && mkdir aws-iot-device-sdk-cpp-v2-build \
-    && git clone --recursive https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
+    && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
     && git checkout a73593d1003e2b231c6db53710aa6c75d8196b1f \
-    && cd ../aws-iot-device-sdk-cpp-v2-build \
+    && git submodule update --init --recursive \
+    && cd .. \
+    && mkdir aws-iot-device-sdk-cpp-v2-build \
+    && cd aws-iot-device-sdk-cpp-v2-build \
     && cmake -DCMAKE_INSTALL_PREFIX="/usr" -DUSE_OPENSSL=ON -DBUILD_DEPS=ON ../aws-iot-device-sdk-cpp-v2 \
     && cmake --build . --target install
 

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -23,11 +23,11 @@ RUN yum --disableplugin=subscription-manager -y update \
 WORKDIR /tmp
 RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
     && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \ 
+    && cd cmake-3.10.0 \
     && ./bootstrap \
     && make -j 4 \
     && make install
-    
+
 ###############################################################################
 # Install OpenSSL 1.1.1
 ###############################################################################
@@ -59,11 +59,12 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
 WORKDIR /home/aws-iot-device-client
 RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
-    && mkdir aws-iot-device-sdk-cpp-v2-build \
-    && git clone --recursive https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
-    && cd aws-iot-device-sdk-cpp-v2 \
+    && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && git checkout a73593d1003e2b231c6db53710aa6c75d8196b1f \
-    && cd ../aws-iot-device-sdk-cpp-v2-build \
+    && git submodule update --init --recursive \
+    && cd .. \
+    && mkdir aws-iot-device-sdk-cpp-v2-build \
+    && cd aws-iot-device-sdk-cpp-v2-build \
     && cmake -DCMAKE_INSTALL_PREFIX="/usr" -DUSE_OPENSSL=ON -DBUILD_DEPS=ON ../aws-iot-device-sdk-cpp-v2 \
     && cmake --build . --target install
 

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -31,7 +31,7 @@ RUN wget https://www.openssl.org/source/openssl-1.1.1.tar.gz \
 WORKDIR /tmp
 RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
     && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \ 
+    && cd cmake-3.10.0 \
     && ./bootstrap \
     && make -j 2 \
     && make install
@@ -55,11 +55,12 @@ RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
 WORKDIR /home/aws-iot-device-client
 RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
-    && mkdir aws-iot-device-sdk-cpp-v2-build \
-    && git clone --recursive https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
-    && cd aws-iot-device-sdk-cpp-v2 \
+    && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && git checkout a73593d1003e2b231c6db53710aa6c75d8196b1f \
-    && cd ../aws-iot-device-sdk-cpp-v2-build \
+    && git submodule update --init --recursive \
+    && cd .. \
+    && mkdir aws-iot-device-sdk-cpp-v2-build \
+    && cd aws-iot-device-sdk-cpp-v2-build \
     && cmake -DCMAKE_INSTALL_PREFIX="/usr" -DUSE_OPENSSL=ON -DBUILD_DEPS=ON ../aws-iot-device-sdk-cpp-v2 \
     && cmake --build . --target install
 


### PR DESCRIPTION
### Motivation
- Release builds require git submodules to be pinned to known versions.
- Dockerfile build will perform git submodule update before checking out release version. As a result, the release build might not use the intended version of submodule dependencies.  This results in broken builds or builds inadvertently compiled with an incompatible dependent version.

### Modifications
#### Change summary
- Change the order in Dockerfile build so that we checkout release version before git submodule update.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

N/A

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
