### PR TITLE
Added support for fetching Job Handler directory field from config file

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -615,7 +615,8 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     }
 
     jsonKey = JSON_KEY_HANDLER_DIR;
-    if (json.ValueExists(jsonKey)) {
+    if (json.ValueExists(jsonKey))
+    {
         handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
     }
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -614,6 +614,11 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
         enabled = json.GetBool(jsonKey);
     }
 
+    jsonKey = JSON_KEY_HANDLER_DIR;
+    if (json.ValueExists(jsonKey)) {
+        handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- We were not storing Job Handler Directory field from Jobs feature config file.

### Modifications
#### Change summary
- Added support for fetching Job Handler directory field from config file

#### Revision diff summary

N/A

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>
- Manually tested the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
