### PR TITLE
Handler typo

### DIFF
--- a/sample-job-handlers/restart-services.sh
+++ b/sample-job-handlers/restart-services.sh
@@ -24,10 +24,10 @@ then
   for service in $services
   do
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n service restart "$service"
+      sudo -u "$user" -n service "$service" restart
     else
       echo "username or sudo command not found"
-      service restart "$service"
+      service "$service" restart
     fi
   done
 else

--- a/sample-job-handlers/start-services.sh
+++ b/sample-job-handlers/start-services.sh
@@ -24,10 +24,10 @@ then
   for service in $services
   do
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n service start "$service"
+      sudo -u "$user" -n service "$service" start
     else
       echo "username or sudo command not found"
-      service start "$service"
+      service "$service" start
     fi
   done
 fi

--- a/sample-job-handlers/stop-services.sh
+++ b/sample-job-handlers/stop-services.sh
@@ -24,10 +24,10 @@ then
   for service in $services
   do
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n service stop "$service"
+      sudo -u "$user" -n service "$service" stop
     else
       echo "username or sudo command not found"
-      service stop "$service"
+      service "$service" stop
     fi
   done
 fi

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -615,7 +615,8 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     }
 
     jsonKey = JSON_KEY_HANDLER_DIR;
-    if (json.ValueExists(jsonKey)) {
+    if (json.ValueExists(jsonKey))
+    {
         handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
     }
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -614,6 +614,11 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
         enabled = json.GetBool(jsonKey);
     }
 
+    jsonKey = JSON_KEY_HANDLER_DIR;
+    if (json.ValueExists(jsonKey)) {
+        handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+    }
+
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- The `service_name` should appear before `command` in service job handlers, but are transposed.  As a result, the handler will always fail.


### Modifications
#### Change summary
- Reorder so that `service_name` appears before `command` in service job handlers. 

#### Revision diff summary
N/A

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
