### PR TITLE
Added support handler directory paths ending with '/'

### DIFF
--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -99,15 +99,16 @@ string JobEngine::buildCommand(Optional<string> path, std::string handler, std::
             "Using path {%s} supplied by job document for command execution",
             Util::Sanitize(path.value()).c_str());
         commandStream << path.value();
-        constexpr char separator = '/';
-        if (path.value().back() != separator)
-        {
-            commandStream << separator;
-        }
     }
     else
     {
         LOG_DEBUG(TAG, "Assuming executable is in PATH");
+    }
+
+    constexpr char separator = '/';
+    if (path.value().back() != separator)
+    {
+        commandStream << separator;
     }
 
     commandStream << handler.c_str();


### PR DESCRIPTION
### Motivation
- Added support to add '/' in the end for job handler directory path.


### Modifications
#### Change summary
- Added support to add '/' in the end for job handler directory path.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
* Manually tested


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
