### PR TITLE
Append subdirectories of device client current working directory to PATH

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1855,3 +1855,13 @@ bool Config::ExportDefaultSetting(const string &file)
     FileUtils::ValidateFilePermissions(file.c_str(), Permissions::CONFIG_FILE, false);
     return true;
 }
+
+string Config::ExpandDefaultConfigDir(bool removeTrailingSeparator)
+{
+    string expandedConfigDir = FileUtils::ExtractExpandedPath(DEFAULT_CONFIG_DIR);
+    if (removeTrailingSeparator)
+    {
+        return Util::TrimRightCopy(expandedConfigDir, string{Config::PATH_DIRECTORY_SEPARATOR});
+    }
+    return expandedConfigDir;
+}

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -339,6 +339,17 @@ namespace Aws
                 bool ParseConfigFile(const std::string &file, bool isRuntimeConfig);
                 bool init(const CliArgs &cliArgs);
 
+                /**
+                 * \brief Separator between directories in path.
+                 */
+                static constexpr char PATH_DIRECTORY_SEPARATOR = '/';
+
+                /**
+                 * \brief Use path expansion to return absolute path to device client default configuration directory.
+                 * @return
+                 */
+                static std::string ExpandDefaultConfigDir(bool removeTrailingSeparator = false);
+
                 PlainConfig config;
 
               private:

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "JobEngine.h"
+#include "../config/Config.h"
 #include "../logging/LoggerFactory.h"
 
 #include <array>
@@ -91,6 +92,10 @@ string JobEngine::buildCommand(Optional<string> path, std::string handler, std::
             TAG, "Using DC default command path {%s} for command execution", Util::Sanitize(jobHandlerDir).c_str());
         operationOwnedByDeviceClient = true;
         commandStream << jobHandlerDir;
+        if (jobHandlerDir.back() != Config::PATH_DIRECTORY_SEPARATOR)
+        {
+            commandStream << Config::PATH_DIRECTORY_SEPARATOR;
+        }
     }
     else if (path.has_value() && !path.value().empty())
     {
@@ -99,10 +104,9 @@ string JobEngine::buildCommand(Optional<string> path, std::string handler, std::
             "Using path {%s} supplied by job document for command execution",
             Util::Sanitize(path.value()).c_str());
         commandStream << path.value();
-        constexpr char separator = '/';
-        if (path.value().back() != separator)
+        if (path.value().back() != Config::PATH_DIRECTORY_SEPARATOR)
         {
-            commandStream << separator;
+            commandStream << Config::PATH_DIRECTORY_SEPARATOR;
         }
     }
     else

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -99,16 +99,15 @@ string JobEngine::buildCommand(Optional<string> path, std::string handler, std::
             "Using path {%s} supplied by job document for command execution",
             Util::Sanitize(path.value()).c_str());
         commandStream << path.value();
+        constexpr char separator = '/';
+        if (path.value().back() != separator)
+        {
+            commandStream << separator;
+        }
     }
     else
     {
         LOG_DEBUG(TAG, "Assuming executable is in PATH");
-    }
-
-    constexpr char separator = '/';
-    if (path.value().back() != separator)
-    {
-        commandStream << separator;
     }
 
     commandStream << handler.c_str();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,6 +6,7 @@
 #include "SharedCrtResourceManager.h"
 #include "Version.h"
 #include "config/Config.h"
+#include "util/EnvUtils.h"
 #include "util/Retry.h"
 
 #if !defined(EXCLUDE_DD)
@@ -264,6 +265,15 @@ int main(int argc, char *argv[])
         // We attempted to start a non-stdout logger and failed, so we should fall back to STDOUT
         config.config.logConfig.deviceClientLogtype = config.config.logConfig.LOG_TYPE_STDOUT;
         LoggerFactory::reconfigure(config.config);
+    }
+
+    EnvUtils envUtils;
+    if (envUtils.AppendCwdToPath())
+    {
+        // Failure to append current working directory is not a fatal error,
+        // but some features of device client such as standard job execution
+        // might not work without explicitly setting path to handler in job document.
+        LOG_WARN(TAG, "Unable to append current working directory to PATH environment variable.");
     }
 
     LOGM_INFO(

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
     if (envUtils.AppendCwdToPath())
     {
         // Failure to append current working directory is not a fatal error,
-        // but some features of device client such as standard job execution
+        // but some features of device client such as standard job action
         // might not work without explicitly setting path to handler in job document.
         LOG_WARN(TAG, "Unable to append current working directory to PATH environment variable.");
     }

--- a/source/util/EnvUtils.cpp
+++ b/source/util/EnvUtils.cpp
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "EnvUtils.h"
+#include "../logging/LoggerFactory.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <sstream>
+#include <vector>
+
+#include <linux/limits.h>
+#include <string.h>
+#include <unistd.h>
+
+using namespace Aws::Iot::DeviceClient::Util;
+using namespace Aws::Iot::DeviceClient::Logging;
+
+char *OSInterfacePosix::getenv(const char *name)
+{
+    return ::getenv(name);
+}
+
+int OSInterfacePosix::setenv(const char *name, const char *value, int overwrite)
+{
+    return ::setenv(name, value, overwrite);
+}
+
+char *OSInterfacePosix::getcwd(char *buf, size_t size)
+{
+    return ::getcwd(buf, size);
+}
+
+// Sequences of path prefixes used to search for executable filenames.
+constexpr char PATH_ENVIRONMENT[] = "PATH";
+
+// Separator between path prefixes in environment variable.
+constexpr char PATH_ENVIRONMENT_SEPARATOR = ':'; // Unix-only.
+
+// Separator between directories in path.
+constexpr char PATH_DIRECTORY_SEPARATOR = '/'; // Unix-only.
+
+// Jobs directory name.
+constexpr char JOBS_DIRECTORY_NAME[] = "jobs";
+
+constexpr char TAG[] = __FILE__;
+
+int EnvUtils::AppendCwdToPath()
+{
+    // Use a vector of char as buffer for path to current working directory.
+    //
+    // Maximum number of characters in absolute path is filesystem dependent.
+    //
+    // The getcwd function takes a buffer and length and returns the current
+    // working directory or NULL if the length of the buffer is insufficient
+    // to store the current working directory.
+    //
+    // As a result, we initialize the buffer with the maximum length of a
+    // relative pathname (_PC_PATH_MAX) and then repeatedly resize the buffer
+    // in the event that getcwd is unable to fit the current working directory
+    // in the buffer passed as input.
+    std::vector<char> cwd;
+    long path_max = pathconf(".", _PC_PATH_MAX);
+    if (path_max < 1)
+    {
+        cwd.resize(PATH_MAX + 1, '\0'); // Fallback to hardcoded PATH_MAX.
+    }
+    else
+    {
+        cwd.resize(path_max + 1, '\0');
+    }
+
+    char *pcwd = nullptr;
+    while (!pcwd)
+    {
+        pcwd = os->getcwd(cwd.data(), cwd.size() - 1); // Leave room for terminating null.
+        if (!pcwd)
+        {
+            if (errno == ERANGE)
+            {
+                cwd.resize(cwd.size() * 2, '\0');
+            }
+            else
+            {
+                int errnum = errno != 0 ? errno : 1;
+                LOGM_ERROR(TAG, "Unable to get current working directory errno: %d msg: %s", errnum, strerror(errnum));
+                return errnum;
+            }
+        }
+    }
+
+    // Append standard paths used by device client based on current working directory.
+    std::ostringstream oss;
+    if (const char *path = os->getenv(PATH_ENVIRONMENT))
+    {
+        oss << path;
+    }
+    if (oss.tellp())
+    {
+        oss << PATH_ENVIRONMENT_SEPARATOR;
+    }
+    oss << cwd.data() // Current working directory.
+        << PATH_ENVIRONMENT_SEPARATOR << cwd.data() << PATH_DIRECTORY_SEPARATOR
+        << JOBS_DIRECTORY_NAME; // Jobs subdirectory.
+
+    // Overwrite path environment variable.
+    const std::string &newpath = oss.str();
+    if (os->setenv(PATH_ENVIRONMENT, newpath.c_str(), 1) != 0)
+    {
+        int errnum = errno != 0 ? errno : 1;
+        LOGM_ERROR(
+            TAG,
+            "Unable to overwrite %s environment variable errno: %d msg: %s",
+            PATH_ENVIRONMENT,
+            errnum,
+            strerror(errnum));
+        return errnum;
+    }
+    LOGM_DEBUG(TAG, "Updated %s environment variable to: %s", PATH_ENVIRONMENT, newpath.c_str());
+
+    return 0;
+}

--- a/source/util/EnvUtils.cpp
+++ b/source/util/EnvUtils.cpp
@@ -43,7 +43,7 @@ constexpr char PATH_DIRECTORY_SEPARATOR = '/'; // Unix-only.
 // Jobs directory name.
 constexpr char JOBS_DIRECTORY_NAME[] = "jobs";
 
-constexpr char TAG[] = __FILE__;
+constexpr char EnvUtils::TAG[];
 
 int EnvUtils::AppendCwdToPath()
 {
@@ -82,7 +82,7 @@ int EnvUtils::AppendCwdToPath()
             }
             else
             {
-                int errnum = errno != 0 ? errno : 1;
+                auto errnum = errno != 0 ? errno : 1;
                 LOGM_ERROR(TAG, "Unable to get current working directory errno: %d msg: %s", errnum, strerror(errnum));
                 return errnum;
             }
@@ -107,7 +107,7 @@ int EnvUtils::AppendCwdToPath()
     const std::string &newpath = oss.str();
     if (os->setenv(PATH_ENVIRONMENT, newpath.c_str(), 1) != 0)
     {
-        int errnum = errno != 0 ? errno : 1;
+        auto errnum = errno != 0 ? errno : 1;
         LOGM_ERROR(
             TAG,
             "Unable to overwrite %s environment variable errno: %d msg: %s",

--- a/source/util/EnvUtils.h
+++ b/source/util/EnvUtils.h
@@ -60,6 +60,9 @@ namespace Aws
                  */
                 struct EnvUtils
                 {
+                  private:
+                    static constexpr char TAG[] = "EnvUtils.cpp";
+
                   public:
                     using OSInterfacePtr = std::unique_ptr<OSInterface>;
 

--- a/source/util/EnvUtils.h
+++ b/source/util/EnvUtils.h
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef AWS_IOT_DEVICE_CLIENT_ENVUTILS_H
+#define AWS_IOT_DEVICE_CLIENT_ENVUTILS_H
+
+#include <memory>
+
+namespace Aws
+{
+    namespace Iot
+    {
+        namespace DeviceClient
+        {
+            namespace Util
+            {
+                /**
+                 * \brief OSInterface presents an interface to the operating system.
+                 */
+                struct OSInterface
+                {
+                    virtual ~OSInterface() = default;
+                    virtual char *getenv(const char *name) = 0;
+                    virtual int setenv(const char *name, const char *value, int overwrite) = 0;
+                    virtual char *getcwd(char *buf, size_t size) = 0;
+                };
+
+                /**
+                 * \brief OSInterfacePosix is an operating system interface using posix system calls.
+                 */
+                struct OSInterfacePosix : public OSInterface
+                {
+                    /**
+                     * \brief Get get value of an environment variable.
+                     * @param name Environment variable name
+                     * @return Pointer to environment variable value or nullptr
+                     */
+                    char *getenv(const char *name) override;
+
+                    /**
+                     * \brief Add or change environment variable.
+                     * @param name Environment variable name
+                     * @param value Environment variable value
+                     * @param overwrite Replace environment variable value when non-zero
+                     * @return 0 on success or non-zero on error
+                     */
+                    int setenv(const char *name, const char *value, int overwrite) override;
+
+                    /**
+                     * \brief Get the absolute pathname of the current working directory.
+                     * @param buf Array of characters in which to store returned working directory
+                     * @param size Size in bytes of the array pointed to by buf
+                     * @return Pointer to buffer passed as input or nullptr if length of pathname exceeds size of buffer
+                     */
+                    char *getcwd(char *buf, size_t size) override;
+                };
+
+                /**
+                 * \brief Utility functions for managing environment variables.
+                 */
+                struct EnvUtils
+                {
+                  public:
+                    using OSInterfacePtr = std::unique_ptr<OSInterface>;
+
+                    EnvUtils() : os(new OSInterfacePosix) {}
+
+                    EnvUtils(OSInterfacePtr os) : os(std::move(os)) {}
+
+                    /**
+                     * \brief Append the current working directory to PATH environment variable.
+                     * @return 0 on success or non-zero on error
+                     */
+                    int AppendCwdToPath();
+
+                  protected:
+                    OSInterfacePtr os;
+                };
+            } // namespace Util
+        }     // namespace DeviceClient
+    }         // namespace Iot
+} // namespace Aws
+#endif // AWS_IOT_DEVICE_CLIENT_ENVUTILS_H

--- a/source/util/EnvUtils.h
+++ b/source/util/EnvUtils.h
@@ -31,7 +31,7 @@ namespace Aws
                 struct OSInterfacePosix : public OSInterface
                 {
                     /**
-                     * \brief Get get value of an environment variable.
+                     * \brief Get value of an environment variable.
                      * @param name Environment variable name
                      * @return Pointer to environment variable value or nullptr
                      */

--- a/source/util/StringUtils.cpp
+++ b/source/util/StringUtils.cpp
@@ -87,6 +87,17 @@ namespace Aws
                     result.erase(remove(result.begin(), result.end(), '\0'), result.end());
                     return result;
                 }
+
+                string TrimLeftCopy(string s, const string &any) { return s.erase(0, s.find_first_not_of(any)); }
+
+                string TrimRightCopy(string s, const string &any) { return s.erase(s.find_last_not_of(any) + 1); }
+
+                string TrimCopy(string s, const string &any)
+                {
+                    s.erase(0, s.find_first_not_of(any));
+                    s.erase(s.find_last_not_of(any) + 1);
+                    return s;
+                }
             } // namespace Util
         }     // namespace DeviceClient
     }         // namespace Iot

--- a/source/util/StringUtils.h
+++ b/source/util/StringUtils.h
@@ -50,6 +50,7 @@ namespace Aws
                  */
 
                 std::string addString(Aws::Crt::String first, Aws::Crt::String second);
+
                 /**
                  * \brief Given an input map object, will return the string form of the map
                  *
@@ -57,6 +58,30 @@ namespace Aws
                  * @return string form of map
                  */
                 std::string MapToString(Crt::Optional<Crt::Map<Aws::Crt::String, Aws::Crt::String>>);
+
+                /**
+                 * \brief Return a copy of the string with the leftmost characters from a set removed.
+                 * @param s Input string
+                 * @param any Set of characters removed
+                 * @return string with leftmost characters removed
+                 */
+                std::string TrimLeftCopy(std::string s, const std::string &any);
+
+                /**
+                 * \brief Return a copy of the string with the rightmost characters from a set removed.
+                 * @param s Input string
+                 * @param any Set of characters removed
+                 * @return string with rightmost characters removed
+                 */
+                std::string TrimRightCopy(std::string s, const std::string &any);
+
+                /**
+                 * \brief Return a copy of the string with the leftmost and rightmost characters from a set removed.
+                 * @param s Input string
+                 * @param any Set of characters removed
+                 * @return string with leftmost and rightmost characters removed
+                 */
+                std::string TrimCopy(std::string s, const std::string &any);
             } // namespace Util
         }     // namespace DeviceClient
     }         // namespace Iot

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,7 @@ if (NOT EXCLUDE_JOBS)
 endif ()
 
 target_link_libraries(${GTEST_PROJECT} gtest gtest_main)
+target_link_libraries(${GTEST_PROJECT} gmock gmock_main)
 target_link_libraries(${GTEST_PROJECT} ${DEP_DC_LIBS})
 target_link_libraries(${GTEST_PROJECT} OpenSSL::SSL)
 target_link_libraries(${GTEST_PROJECT} OpenSSL::Crypto)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,7 +100,6 @@ if (NOT EXCLUDE_JOBS)
 endif ()
 
 target_link_libraries(${GTEST_PROJECT} gtest gtest_main)
-target_link_libraries(${GTEST_PROJECT} gmock gmock_main)
 target_link_libraries(${GTEST_PROJECT} ${DEP_DC_LIBS})
 target_link_libraries(${GTEST_PROJECT} OpenSSL::SSL)
 target_link_libraries(${GTEST_PROJECT} OpenSSL::Crypto)

--- a/test/util/TestEnvUtils.cpp
+++ b/test/util/TestEnvUtils.cpp
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../source/util/EnvUtils.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <iterator>
+#include <memory>
+#include <string>
+
+using namespace Aws::Iot::DeviceClient::Util;
+
+static const char DEFAULT_PATH[] = "/usr/bin:/usr/local/bin";
+
+struct FakeOSInterface : public OSInterface
+{
+  public:
+    char *getenv(const char *name) override
+    {
+        return getenv_retval.empty() ? nullptr : const_cast<char *>(getenv_retval.data());
+    }
+
+    int setenv(const char *name, const char *value, int overwrite) override
+    {
+        if (setenv_name == name)
+        {
+            setenv_value = value;
+        }
+        return setenv_retval;
+    }
+
+    char *getcwd(char *buf, size_t size) override
+    {
+        if (!getcwd_retval.empty() && getcwd_retval.size() < size)
+        {
+            std::copy_n(std::begin(getcwd_retval), getcwd_retval.size(), buf);
+            buf[getcwd_retval.size()] = '\0';
+            return buf;
+        }
+        if (getcwd_errno)
+        {
+            errno = getcwd_errno;
+        }
+        return nullptr;
+    }
+
+    std::string getenv_retval{"/usr/bin:/usr/local/bin"};
+    std::string setenv_name{"PATH"};
+    std::string setenv_value;
+    int setenv_retval{0};
+    std::string getcwd_retval{"/tmp"};
+    int getcwd_errno{0};
+};
+
+struct FakeEnvUtils : public EnvUtils
+{
+  public:
+    FakeEnvUtils(FakeOSInterface *os) : EnvUtils(OSInterfacePtr(os)) {}
+
+    FakeOSInterface *getOS() { return dynamic_cast<FakeOSInterface *>(os.get()); }
+};
+
+TEST(EnvUtils, handleSetPath)
+{
+    FakeEnvUtils envUtils(new FakeOSInterface);
+    envUtils.getOS()->getcwd_retval = "/tmp";
+
+    ASSERT_EQ(0, envUtils.AppendCwdToPath());
+    ASSERT_EQ("/usr/bin:/usr/local/bin:/tmp:/tmp/jobs", envUtils.getOS()->setenv_value);
+}
+
+TEST(EnvUtils, handleUnsetPath)
+{
+    FakeEnvUtils envUtils(new FakeOSInterface);
+    envUtils.getOS()->getenv_retval.clear();
+    envUtils.getOS()->getcwd_retval = "/tmp";
+
+    ASSERT_EQ(0, envUtils.AppendCwdToPath());
+    ASSERT_EQ("/tmp:/tmp/jobs", envUtils.getOS()->setenv_value);
+}
+
+TEST(EnvUtils, handleGetcwdError)
+{
+    FakeEnvUtils envUtils(new FakeOSInterface);
+    envUtils.getOS()->getcwd_retval.clear();
+    envUtils.getOS()->getcwd_errno = 1;
+
+    ASSERT_EQ(1, envUtils.AppendCwdToPath());
+}
+
+TEST(EnvUtils, handleSetenvError)
+{
+    FakeEnvUtils envUtils(new FakeOSInterface);
+    envUtils.getOS()->setenv_retval = 1;
+
+    ASSERT_EQ(1, envUtils.AppendCwdToPath());
+}

--- a/test/util/TestStringUtils.cpp
+++ b/test/util/TestStringUtils.cpp
@@ -69,3 +69,45 @@ TEST(StringUtils, emptyMaptoString)
     string expected = "";
     ASSERT_STREQ(expected.c_str(), MapToString(map).c_str());
 }
+
+TEST(StringUtils, trimLeftSingleChar)
+{
+    ASSERT_EQ("a/b/c/", TrimLeftCopy("/a/b/c/", "/")); // Match.
+    ASSERT_EQ("a/b/c/", TrimLeftCopy("a/b/c/", "/"));  // No match.
+    ASSERT_EQ("", TrimLeftCopy("", "/"));              // Empty string.
+}
+
+TEST(StringUtils, trimLeftMultiChar)
+{
+    ASSERT_EQ("c/", TrimLeftCopy("/a/b/c/", "/ab"));   // Match.
+    ASSERT_EQ("/a/b/c", TrimLeftCopy("/a/b/c", "ab")); // No match.
+    ASSERT_EQ("", TrimLeftCopy("", "/"));              // Empty string.
+}
+
+TEST(StringUtils, trimRightSingleChar)
+{
+    ASSERT_EQ("/a/b/c", TrimRightCopy("/a/b/c/", "/")); // Match.
+    ASSERT_EQ("/a/b/c", TrimRightCopy("/a/b/c", "/"));  // No match.
+    ASSERT_EQ("", TrimRightCopy("", "/"));              // Empty string.
+}
+
+TEST(StringUtils, trimRightMultiChar)
+{
+    ASSERT_EQ("/a", TrimRightCopy("/a/b/c/", "/bc"));     // Match.
+    ASSERT_EQ("/a/b/c/", TrimRightCopy("/a/b/c/", "bc")); // No match.
+    ASSERT_EQ("", TrimRightCopy("", "/"));                // Empty string.
+}
+
+TEST(StringUtils, trimSingleChar)
+{
+    ASSERT_EQ("a/b/c", TrimCopy("/a/b/c/", "/")); // Match.
+    ASSERT_EQ("a/b/c", TrimCopy("a/b/c", "/"));   // No match.
+    ASSERT_EQ("", TrimCopy("", "/"));             // Empty string.
+}
+
+TEST(StringUtils, trimMultiChar)
+{
+    ASSERT_EQ("b", TrimCopy("/a/b/c/", "/ac"));      // Match.
+    ASSERT_EQ("/a/b/c/", TrimCopy("/a/b/c/", "ac")); // No match.
+    ASSERT_EQ("", TrimCopy("", "/"));                // Empty string.
+}


### PR DESCRIPTION
### Motivation
* Managed job templates feature will look for job handlers in `./job` subdirectory of the default device client config directory and device client current working directory.


### Modifications
#### Change summary
* On startup, add both the default device client config directory and the current working directory as well as standard subdirectories (`./job`) to the `PATH` environment variable.
* This is the value of PATH that is set and logged on startup when I run device client on my ubuntu 20 image.
```
/usr/local/sbin:
/usr/local/bin:
/usr/sbin:
/usr/bin:
/sbin:
/bin:
/root/.aws-iot-device-client:           << added to PATH by device client on startup 
/root/.aws-iot-device-client/jobs:      << added to PATH by device client on startup 
/tmp/aws-iot-device-client-clion:       << added to PATH by device client on startup 
/tmp/aws-iot-device-client-clion/jobs   << added to PATH by device client on startup 
```

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
* Unit tests that exercise the feature by faking out POSIX system calls to get and set environment variables and the current working directory.
* Functional test using local builds of the device client on amazonlinux2 and ubuntu:20.04.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
