### PR TITLE
Add PubSub features to CLI ArgumentDefinition

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1457,6 +1457,12 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
         {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_CSR_FILE, true, false, nullptr},
         {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_DEVICE_KEY, true, false, nullptr},
 
+        {PlainConfig::PubSub::CLI_ENABLE_PUB_SUB, true, false, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_TOPIC, true, false, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_FILE, true, false, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_TOPIC, true, false, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_FILE, true, false, nullptr},
+
         {PlainConfig::SampleShadow::CLI_ENABLE_SAMPLE_SHADOW, true, false, nullptr},
         {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_NAME, true, false, nullptr},
         {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_INPUT_FILE, true, false, nullptr},


### PR DESCRIPTION
### Motivation
- All of the pub-sub related cli arguments (pasted below) were accidentally omitted from Config::ArgumentDefinition which means that users cannot pass these arguments from the cli.
  - `--enable-pub-sub`
  - `--publish-topic`
  - `--publish-file`
  - `--subscribe-topic`
  - `--subscribe-file`
- Adds PubSub cli arguments to ArgumentDefinition.
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/181


### Modifications
#### Change summary
- Add pub-sub related cli arguments to Config::ArgumentDefinition.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
- Tested that behavior of all arguments passed using the cli is equivalent to passing in config file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
