### PR TITLE
Setup SDK logging from Config as part of CRT SDK initialization

### DIFF
--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -31,6 +31,14 @@ namespace Aws
                 const char *BINARY_NAME = "IoTDeviceClient";
                 const char *BINARY_VERSION = "1.2";
 
+                /**
+                 * \brief Full path to the default log file used by the AWS CRT SDK.
+                 *
+                 * If the user does not specify a desired log location in either the command line arguments
+                 * or the Json configuration file, this is the default log that will be used
+                 */
+                static constexpr char DEFAULT_SDK_LOG_FILE[] = "/var/log/aws-iot-device-client/sdk.log";
+
                 static constexpr int DEFAULT_WAIT_TIME_SECONDS = 10;
                 bool initialized = false;
                 std::atomic<bool> initializedAWSHttpLib{false};
@@ -45,6 +53,7 @@ namespace Aws
                 std::vector<Feature *> *features;
 
                 bool locateCredentials(const PlainConfig &config);
+                bool setupLogging(const PlainConfig &config);
                 int buildClient(const PlainConfig &config);
                 void initializeAllocator();
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -344,8 +344,6 @@ constexpr char PlainConfig::LogConfig::JSON_KEY_ENABLE_SDK_LOGGING[];
 constexpr char PlainConfig::LogConfig::JSON_KEY_SDK_LOG_LEVEL[];
 constexpr char PlainConfig::LogConfig::JSON_KEY_SDK_LOG_FILE[];
 
-constexpr char PlainConfig::LogConfig::DEFAULT_SDK_LOG_FILE[];
-
 int PlainConfig::LogConfig::ParseDeviceClientLogLevel(string level)
 {
     string temp = level;
@@ -1763,7 +1761,10 @@ bool Config::ExportDefaultSetting(const string &file)
     "%s": {
         "%s": "DEBUG",
         "%s": "FILE",
-        "%s": "/var/log/aws-iot-device-client/aws-iot-device-client.log"
+        "%s": "/var/log/aws-iot-device-client/aws-iot-device-client.log",
+        "%s": false,
+        "%s": "TRACE",
+        "%s": "/var/log/aws-iot-device-client/sdk.log"
     },
     "%s": {
         "%s": true,
@@ -1819,6 +1820,9 @@ bool Config::ExportDefaultSetting(const string &file)
         PlainConfig::LogConfig::JSON_KEY_LOG_LEVEL,
         PlainConfig::LogConfig::JSON_KEY_LOG_TYPE,
         PlainConfig::LogConfig::JSON_KEY_LOG_FILE,
+        PlainConfig::LogConfig::JSON_KEY_ENABLE_SDK_LOGGING,
+        PlainConfig::LogConfig::JSON_KEY_SDK_LOG_LEVEL,
+        PlainConfig::LogConfig::JSON_KEY_SDK_LOG_FILE,
         PlainConfig::JSON_KEY_JOBS,
         PlainConfig::Jobs::JSON_KEY_ENABLED,
         PlainConfig::Jobs::JSON_KEY_HANDLER_DIR,

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -120,14 +120,13 @@ namespace Aws
                     static constexpr char JSON_KEY_SDK_LOG_LEVEL[] = "sdk-log-level";
                     static constexpr char JSON_KEY_SDK_LOG_FILE[] = "sdk-log-file";
 
-                    static constexpr char DEFAULT_SDK_LOG_FILE[] = "/var/log/aws-iot-device-client/sdk.log";
-
                     int deviceClientlogLevel{3};
                     std::string deviceClientLogtype;
                     std::string deviceClientLogFile;
+
                     bool sdkLoggingEnabled = false;
                     Aws::Crt::LogLevel sdkLogLevel = Aws::Crt::LogLevel::Trace;
-                    std::string sdkLogFile = DEFAULT_SDK_LOG_FILE;
+                    std::string sdkLogFile;
                 };
                 LogConfig logConfig;
 

--- a/source/util/FileUtils.h
+++ b/source/util/FileUtils.h
@@ -134,6 +134,21 @@ namespace Aws
                     static bool CreateDirectoryWithPermissions(const char *dirPath, mode_t permissions);
 
                     /**
+                     * \brief Check if the path exists and refers to a directory
+                     * @param dirPath the path to the directory
+                     * @return true if the path exists and is a directory, false otherwise
+                     */
+                    static bool DirectoryExists(const std::string &dirPath);
+
+                    /**
+                     * \brief Create an empty file with the given permissions
+                     * @param filename the path to the file
+                     * @param permissions the permission mask that should be applied to the file
+                     * @return true if the file was successfully created with the given permissions, false otherwise
+                     */
+                    static bool CreateEmptyFileWithPermissions(const std::string &filename, mode_t permissions);
+
+                    /**
                      * \brief Check if the given filename exists
                      *
                      * @param filename File Path to the Filename to check

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -345,7 +345,6 @@ TEST(Config, SDKLoggingConfigurationCLIDefaults)
 
     ASSERT_FALSE(config.logConfig.sdkLoggingEnabled);
     ASSERT_EQ(Aws::Crt::LogLevel::Trace, config.logConfig.sdkLogLevel);
-    ASSERT_STREQ(PlainConfig::LogConfig::DEFAULT_SDK_LOG_FILE, config.logConfig.sdkLogFile.c_str());
 }
 
 TEST(Config, SDKLoggingConfigurationCLIOverride)
@@ -386,7 +385,6 @@ TEST(Config, SDKLoggingConfigurationJsonDefaults)
 
     ASSERT_FALSE(config.logConfig.sdkLoggingEnabled);
     ASSERT_EQ(Aws::Crt::LogLevel::Trace, config.logConfig.sdkLogLevel);
-    ASSERT_STREQ(PlainConfig::LogConfig::DEFAULT_SDK_LOG_FILE, config.logConfig.sdkLogFile.c_str());
 }
 
 TEST(Config, SDKLoggingConfigurationJson)

--- a/test/util/TestFileUtils.cpp
+++ b/test/util/TestFileUtils.cpp
@@ -222,6 +222,59 @@ TEST(FileUtils, setupDirectoryDetectedSetupFailure)
     ASSERT_FALSE(didSetup);
 }
 
+TEST(FileUtils, DirectoryExistsTrue)
+{
+    string dirPath = "/tmp/" + UniqueString::GetRandomToken(10);
+    ASSERT_EQ(0, mkdir(dirPath.c_str(), S_IRWXU));
+
+    ASSERT_TRUE(FileUtils::DirectoryExists(dirPath));
+}
+
+TEST(FileUtils, DirectoryExistsFalse)
+{
+    string dirPath = "/tmp/" + UniqueString::GetRandomToken(10);
+
+    ASSERT_FALSE(FileUtils::DirectoryExists(dirPath));
+}
+
+TEST(FileUtils, DirectoryExistsFalseIsFile)
+{
+    string filePath = "/tmp/" + UniqueString::GetRandomToken(10);
+    {
+        std::ofstream ofs(filePath, ios::out);
+        ASSERT_TRUE(ofs.is_open());
+        // Close and flush file on exit.
+    }
+
+    ASSERT_FALSE(FileUtils::DirectoryExists(filePath));
+}
+
+TEST(FileUtils, canCreateEmptyFileWithPermissions)
+{
+    string filePath = "/tmp/" + UniqueString::GetRandomToken(10);
+
+    bool didCreate = FileUtils::CreateEmptyFileWithPermissions(filePath.c_str(), S_IRUSR);
+
+    ASSERT_TRUE(didCreate);
+    ASSERT_EQ(400, FileUtils::GetFilePermissions(filePath.c_str()));
+    ASSERT_EQ(0, FileUtils::GetFileSize(filePath.c_str()));
+}
+
+TEST(FileUtils, failCreateEmptyFileWithPermissionsFileExists)
+{
+    string filePath = "/tmp/" + UniqueString::GetRandomToken(10);
+    {
+        std::ofstream ofs(filePath, ios::out);
+        ASSERT_TRUE(ofs.is_open());
+        // Close and flush file on exit.
+    }
+    ASSERT_TRUE(FileUtils::FileExists(filePath));
+
+    bool didCreate = FileUtils::CreateEmptyFileWithPermissions(filePath.c_str(), S_IRUSR);
+
+    ASSERT_FALSE(didCreate);
+}
+
 TEST(FileUtils, FileExists)
 {
     string filePath = "/tmp/" + UniqueString::GetRandomToken(10);


### PR DESCRIPTION
### Motivation
- The SDK logging feature has a few unexpected misbehaviors.
  - If the destination SDK log file does not exist, then SDK logging will silently fail.
  - SDK logging does not enforce the same permissions requirements as device client log.
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/175


### Modifications
#### Change summary
- Add logic to create parent directories and file with expected permissions as part of CRT SDK initialization.
  - This logic is functionally equivalent to behavior of device client log file.
- Add SDK logging configuration to the output of `--export-default-settings`.
- Fix bug in `FileUtils::CreateDirectoryWithPermissions` in return value when desired and actual file permissions match. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
* Tested the behavior of SDK logging with the following permutations.
  * SDK logging options set from the command line and from config file.
  * SDK logging configured with file paths containing directories and files that do not exist.
* Add unit tests to `FileUtlis` for the new functions used in this feature.
* We currently do not have tests for `SharedCrtResourceManager`, this should be added in a future commit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
