### PR TITLE
Added validation check for empty value of job handler directory path

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -615,7 +615,17 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_HANDLER_DIR;
     if (json.ValueExists(jsonKey))
     {
-        handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        if (!json.GetString(jsonKey).empty())
+        {
+            handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+        }
+        else
+        {
+            LOGM_WARN(
+                Config::TAG,
+                "Jobs Handler Directory path {%s} was provided in the JSON configuration file with an empty value",
+                jsonKey);
+        }
     }
 
     return true;

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -613,19 +613,9 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     }
 
     jsonKey = JSON_KEY_HANDLER_DIR;
-    if (json.ValueExists(jsonKey))
+    if (json.ValueExists(jsonKey) && !json.GetString(jsonKey).empty())
     {
-        if (!json.GetString(jsonKey).empty())
-        {
-            handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
-        }
-        else
-        {
-            LOGM_WARN(
-                Config::TAG,
-                "Jobs Handler Directory path {%s} was provided in the JSON configuration file with an empty value",
-                jsonKey);
-        }
+        handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
     }
 
     return true;

--- a/source/util/FileUtils.cpp
+++ b/source/util/FileUtils.cpp
@@ -61,7 +61,8 @@ string FileUtils::ExtractParentDirectory(const string &filePath)
 
 string FileUtils::ExtractExpandedPath(const string &filePath)
 {
-    if (filePath.empty()) {
+    if (filePath.empty())
+    {
         return "";
     }
     wordexp_t word;

--- a/source/util/FileUtils.cpp
+++ b/source/util/FileUtils.cpp
@@ -61,8 +61,11 @@ string FileUtils::ExtractParentDirectory(const string &filePath)
 
 string FileUtils::ExtractExpandedPath(const string &filePath)
 {
+    if (filePath.empty()) {
+        return "";
+    }
     wordexp_t word;
-    wordexp(filePath.c_str(), &word, 0);
+    wordexp(filePath.c_str(), &word, 0); // TODO: How to handle error?
     string expandedPath = word.we_wordv[0];
     wordfree(&word);
     return expandedPath;

--- a/test/util/TestFileUtils.cpp
+++ b/test/util/TestFileUtils.cpp
@@ -56,6 +56,18 @@ TEST(FileUtils, handlesEmptyPath)
     ASSERT_STREQ("./", parentDir.c_str());
 }
 
+TEST(FileUtils, handlesRootDir)
+{
+    string rootDir = FileUtils::ExtractParentDirectory("/");
+    ASSERT_STREQ("/", rootDir.c_str());
+}
+
+TEST(FileUtils, handlesEmptyPathToExtractExpandedPath)
+{
+    string extendedPath = FileUtils::ExtractExpandedPath("");
+    ASSERT_STREQ("", extendedPath.c_str());
+}
+
 TEST(FileUtils, handlesEmptyPathForStoreValueInFile)
 {
     ASSERT_FALSE(FileUtils::StoreValueInFile("", ""));
@@ -65,11 +77,6 @@ TEST(FileUtils, testStoreValueInFile)
 {
     ASSERT_TRUE(FileUtils::StoreValueInFile(
         "This file was created as part of testStoreValueInFile unit test.", "/tmp/testStoreValueInFile.txt"));
-}
-TEST(FileUtils, handlesRootDir)
-{
-    string rootDir = FileUtils::ExtractParentDirectory("/");
-    ASSERT_STREQ("/", rootDir.c_str());
 }
 
 TEST(FileUtils, assertsCorrectFilePermissions)


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: #200 


### Modifications
#### Change summary
The Device Client was failing with an segmentation fault if the value of job handler directory path passed via config file was empty. With this change I have added validation check for empty value of job handler directory path. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test.
- Manually tested the change. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
