### PR TITLE
Updated github workflow to trigger doxygen update on merge event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   update-doxygen:
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push') && (github.ref == 'refs/heads/main'))
+    if: ((github.event.pull_request.merged == true) && (github.ref == 'refs/heads/main'))
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Doxygen CI test was spiking because of wrong condition.


### Modifications
#### Change summary
Updated the condition to trigger doxygen update on merge event.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
