### PR TITLE
Patch secure tunneling bug in aws-c-iot

### DIFF
--- a/CMakeLists.txt.awssdk
+++ b/CMakeLists.txt.awssdk
@@ -7,6 +7,7 @@ ExternalProject_Add(aws-iot-device-sdk-cpp-v2
         GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
         GIT_TAG                 a73593d1003e2b231c6db53710aa6c75d8196b1f
         SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
+        PATCH_COMMAND patch --directory crt/aws-c-iot -p1 -i ${PROJECT_SOURCE_DIR}/patches/aws-c-iot/0001-Fix-secure-tunneling-bug-sending-from-destination-to.patch
         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
         CONFIGURE_COMMAND       ""
         BUILD_COMMAND           ""

--- a/patches/aws-c-iot/0001-Fix-secure-tunneling-bug-sending-from-destination-to.patch
+++ b/patches/aws-c-iot/0001-Fix-secure-tunneling-bug-sending-from-destination-to.patch
@@ -1,0 +1,24 @@
+From de2325d439b5184b30b9542d1cc91b5d3bed7ec1 Mon Sep 17 00:00:00 2001
+From: Marco Morais <marcoaz@amazon.com>
+Date: Tue, 21 Dec 2021 11:13:20 -0800
+Subject: [PATCH] Fix secure tunneling bug sending from destination to source
+
+---
+ source/secure_tunneling.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/source/secure_tunneling.c b/source/secure_tunneling.c
+index 71fbc48..96e1d31 100644
+--- a/source/secure_tunneling.c
++++ b/source/secure_tunneling.c
+@@ -484,7 +484,6 @@ static int s_secure_tunneling_send_data(struct aws_secure_tunnel *secure_tunnel,
+             &secure_tunnel->send_data_mutex,
+             s_can_send_data_status,
+             secure_tunnel);
+-        secure_tunnel->can_send_data = false;
+         aws_mutex_unlock(&secure_tunnel->send_data_mutex);
+ 
+         size_t bytes_max = new_data.len;
+-- 
+2.33.0
+


### PR DESCRIPTION
* Bug in aws-c-iot used by device client results in deadlock when sending files >= 15000 bytes from destination to source.
* Apply patch to commit `a73593d` of `aws-iot-device-sdk-cpp-v2` which pulls in the aws-c-iot as a git submdule.

### Motivation
- Customers reported issues sending large files using secure tunneling.
- Further investigation revealed that the device client secure tunneling thread will always deadlock when sending files >= 15000 bytes from destination to source.
  - No issue for files of any size when sending from source to destination.


### Modifications
#### Change summary
- The root cause of the deadlock is a bug in commit `118c5bf` of the secure tunneling library in `aws-c-iot`.
  - The `aws-c-iot` library is a git submodule pulled in from commit `73593d` of aws-iot-device-sdk-cpp-v2. 
- This commit applies a patch which fixes the bug to the `aws-c-iot` library as part of the cmake build in device client.
  - I will submit a separate PR to `aws-c-iot` with the same patch and unit tests. Until that PR is merged, I recommend for customers to apply the patch in this PR to their device client builds.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
- This change is tested by transferring files of size 1, 10k, 20k, 30k, 100k, 1M between destination and source and comparing checksums of the files on both the destination and source after transfer is complete.
- Additional unit tests for the change are also added to the PR submitted to fix the bug in the `aws-c-iot` library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
