### PR TITLE
Fix for publish of DEFAULT_PUBLISH_PAYLOAD

### DIFF
--- a/source/samples/pubsub/PubSubFeature.cpp
+++ b/source/samples/pubsub/PubSubFeature.cpp
@@ -152,7 +152,7 @@ int PubSubFeature::getPublishFileData(aws_byte_buf *buf)
 void PubSubFeature::publishFileData()
 {
     ByteBuf payload;
-    if (pubFile == "")
+    if (FileUtils::GetFileSize(pubFile) == 0)
     {
         aws_byte_buf_init(&payload, resourceManager->getAllocator(), DEFAULT_PUBLISH_PAYLOAD.size());
         aws_byte_buf_write(&payload, (uint8_t *)DEFAULT_PUBLISH_PAYLOAD.c_str(), DEFAULT_PUBLISH_PAYLOAD.size());


### PR DESCRIPTION
When AWS IoT Device Client is run on a clean install, the PubSub test for "Hello World!" fails.
Fixing it.

### Motivation
- Please give a brief description for the background of this change.
- Issue number: 211
(https://github.com/awslabs/aws-iot-device-client/issues/211)

### Modifications
Line 155 in aws-iot-device-client/source/samples/pubsub/PubSubFeature.cpp publishFileData() fixed.

#### Change summary
See above.

#### Revision diff summary
N/A

### Testing
Tested with and without publish-file.txt file.
Also tested with and without content in the file.
In all 4 cases either "Hello World!" was received or custom message was received in the MQTT test client.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
