### PR TITLE
Attempt to locate OpenSSL on MacOS if pkg-config detection fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,26 @@ configure_file("source/Version.h.in" "${PROJECT_BINARY_DIR}/Version.h")
 # OpenSSL dependency                    #
 #########################################
 set(OPENSSL_USE_STATIC_LIBS TRUE)
+
+if(APPLE)
+    # Try to find OpenSSL on MacOS but don't fail immediately so we can fall back to alternate logic
+    find_package(OpenSSL)
+
+    IF(NOT OpenSSL_FOUND)
+        # OpenSSL was not found by pkg-config which can happen with Homebrew. Attempt to find OpenSSL in Homebrew locations.
+        file(GLOB openssl-candidates /usr/local/Cellar/openssl*/*/)
+
+        # Sort with compare natural to make sure we get numbers in the right order
+        list(SORT openssl-candidates COMPARE NATURAL)
+        # Reverse the list so that our first open is the highest version number
+        list(REVERSE openssl-candidates)
+
+        # Get the first result and set the OPENSSL_ROOT_DIR variable so that the next call to find_package(OpenSSL) finds it or fails
+        list(POP_FRONT openssl-candidates openssl-candidate)
+        set(OPENSSL_ROOT_DIR ${openssl-candidate})
+    endif()
+endif()
+
 find_package(OpenSSL REQUIRED)
 
 #########################################


### PR DESCRIPTION
### Motivation
- On MacOS OpenSSL may not be found by pkg-config. If it is not found the user then has to specify the OpenSSL root directory which they may not know. Since many Mac users use homebrew this patch attempts to use pkg-config to find OpenSSL and then falls back on the Cellar directory.

### Modifications
#### Change summary
One modification to the CMakeLists.txt file that will search for homebrew installations of OpenSSL (on MacOS only) and then find the latest version to build with.

### Testing
No CI for this but I needed to make this change in order to build the project on Mac OS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
