### PR TITLE
Switch to fork from vfork

### DIFF
--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -270,7 +270,7 @@ int JobEngine::exec_cmd(string operation, PlainJobDocument::JobAction action)
 
     int execResult;
     int returnCode;
-    int pid = vfork();
+    int pid = fork();
     if (pid < 0)
     {
         LOGM_ERROR(TAG, "Failed to create child process, fork returned %d", pid);


### PR DESCRIPTION
### Motivation
- The compilation phase on MacOS treats usage of vfork as an error instead of a warning. This changes vfork -> fork to allow compilation on MacOS.
-  
### Modifications
#### Change summary
Just one change of vfork -> fork

### Testing
No CI for this but I needed to make this change in order to build the project on Mac OS. fork does work slightly differently than vfork though so I may add some more comments later once I've verified that it works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
