### PR TITLE
Skip shadow examples on MacOS due to inotify not being supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ option(EXCLUDE_CONFIG_SHADOW "Builds the device client without the IoT Config Sh
 option(EXCLUDE_SAMPLE_SHADOW "Builds the device client without the IoT Sample Shadow Feature." OFF)
 option(GIT_VERSION "Updates the version number using the Git commit history" ON)
 
+if (APPLE)
+    # MacOS does not have inotify which the shadow sample requires
+    SET(EXCLUDE_SHADOW ON BOOL)
+    SET(EXCLUDE_CONFIG_SHADOW ON BOOL)
+    SET(EXCLUDE_SAMPLE_SHADOW ON BOOL)
+endif ()
+
 if (EXCLUDE_JOBS)
     add_definitions(-DEXCLUDE_JOBS)
 endif ()


### PR DESCRIPTION
### Motivation
- MacOS does not support inotify but the shadow example code uses it. On MacOS these examples need to be removed in order for the compilation to be successful.
  
### Modifications
#### Change summary
Added a check in CMakeLists.txt to detect if the system is an Apple operating system. If so, disable the shadow examples.

### Testing
No CI for this but I needed to make this change in order to build the project on Mac OS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
