### PR TITLE
Adds retryable and non-retryable errors for UpdateJobExecutionStatus

### DIFF
--- a/source/jobs/JobsFeature.cpp
+++ b/source/jobs/JobsFeature.cpp
@@ -448,8 +448,10 @@ void JobsFeature::publishUpdateJobExecutionStatus(
         string clientToken = UniqueString::GetRandomToken(10);
         request.ClientToken = Aws::Crt::Optional<Aws::Crt::String>(clientToken.c_str());
         unique_lock<mutex> writeLock(updateJobExecutionPromisesLock);
-        this->updateJobExecutionPromises.insert(std::pair<Aws::Crt::String, EphemeralPromise<UpdateJobExecutionResponseType>>(
-            clientToken.c_str(), EphemeralPromise<UpdateJobExecutionResponseType>(std::chrono::milliseconds(15 * 1000))));
+        this->updateJobExecutionPromises.insert(
+            std::pair<Aws::Crt::String, EphemeralPromise<UpdateJobExecutionResponseType>>(
+                clientToken.c_str(),
+                EphemeralPromise<UpdateJobExecutionResponseType>(std::chrono::milliseconds(15 * 1000))));
         writeLock.unlock();
         LOGM_DEBUG(
             TAG,
@@ -461,7 +463,8 @@ void JobsFeature::publishUpdateJobExecutionStatus(
             AWS_MQTT_QOS_AT_LEAST_ONCE,
             std::bind(&JobsFeature::ackUpdateJobExecutionStatus, this, std::placeholders::_1));
         unique_lock<mutex> futureLock(updateJobExecutionPromisesLock);
-        future<UpdateJobExecutionResponseType> updateFuture = this->updateJobExecutionPromises.at(clientToken.c_str()).get_future();
+        future<UpdateJobExecutionResponseType> updateFuture =
+            this->updateJobExecutionPromises.at(clientToken.c_str()).get_future();
         futureLock.unlock();
         bool finished = false;
         // Although this entire block will be retried based on the retryConfig, we're only waiting for a maximum of 10

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -41,7 +41,6 @@ namespace Aws
                      * to be provided in a StatusDetail entry when calling the UpdateJobExecution API
                      */
                     const size_t MAX_STATUS_DETAIL_LENGTH = 1024;
-                    const int UPDATE_JOB_EXECUTION_REJECTED_CODE = -1;
                     const std::string DEFAULT_JOBS_HANDLER_DIR = "~/.aws-iot-device-client/jobs/";
 
                     /**

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -56,10 +56,21 @@ namespace Aws
                      * \brief A lock used to control access to the map of EphemeralPromise
                      */
                     std::mutex updateJobExecutionPromisesLock;
+
+                    /**
+                     * \brief An enum used for UpdateJobExecution responses
+                     */
+                     enum UpdateJobExecutionResponseType
+                    {
+                        ACCEPTED,
+                        RETRYABLE_ERROR,
+                        NON_RETRYABLE_ERROR
+                    };
+
                     /**
                      * \brief Allows us to map UpdateJobExecution responses back to their original request
                      */
-                    Aws::Crt::Map<Aws::Crt::String, Aws::Iot::DeviceClient::Jobs::EphemeralPromise<int>>
+                    Aws::Crt::Map<Aws::Crt::String, Aws::Iot::DeviceClient::Jobs::EphemeralPromise<UpdateJobExecutionResponseType>>
                         updateJobExecutionPromises;
 
                     std::mutex latestJobsNotificationLock;

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -60,7 +60,7 @@ namespace Aws
                     /**
                      * \brief An enum used for UpdateJobExecution responses
                      */
-                     enum UpdateJobExecutionResponseType
+                    enum UpdateJobExecutionResponseType
                     {
                         ACCEPTED,
                         RETRYABLE_ERROR,
@@ -70,7 +70,9 @@ namespace Aws
                     /**
                      * \brief Allows us to map UpdateJobExecution responses back to their original request
                      */
-                    Aws::Crt::Map<Aws::Crt::String, Aws::Iot::DeviceClient::Jobs::EphemeralPromise<UpdateJobExecutionResponseType>>
+                    Aws::Crt::Map<
+                        Aws::Crt::String,
+                        Aws::Iot::DeviceClient::Jobs::EphemeralPromise<UpdateJobExecutionResponseType>>
                         updateJobExecutionPromises;
 
                     std::mutex latestJobsNotificationLock;


### PR DESCRIPTION
Job Client should only retry JobExecutionStatusUpdates after a retryable error

### Motivation
This was causing delays in high latencies for job execution. 
- Issue number: 


### Modifications
#### Change summary
- Makes only Throttled, ResourceNotFound, and InternalError errors retryable for UpdateJobExecutionStatus
- Adds Job ID to log output to help with debugging.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
