### PR TITLE
Adds additional check for package

### DIFF
--- a/sample-job-handlers/verify-packages-installed.sh
+++ b/sample-job-handlers/verify-packages-installed.sh
@@ -8,28 +8,29 @@ packages=$@
 echo "Username: $user"
 echo "Packages to verify: $packages"
 
-if command -v "rpm" > /dev/null; then
+if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
   for package in $packages
   do
-    if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n rpm -q "$package"
-    else
-      echo "username or sudo command not found"
-      rpm -q "$package"
+    if command -v "rpm" >/dev/null; then
+      if command sudo -u "$user" -n rpm -q "$package" > /dev/null; then
+        continue
+      fi
     fi
-  done
-elif command -v "dpkg" > /dev/null; then
-  # Using -s flag instead of -l for dpkg based on https://github.com/bitrise-io/bitrise/issues/433
-  for package in $packages
-  do
-    if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
+    if command -v "dpkg" >/dev/null; then
       sudo -u "$user" -n dpkg -s "$package"
-    else
-      echo "username or sudo command not found"
-      dpkg -s "$package"
     fi
   done
 else
-  >&2 echo "No suitable package manager found"
-  exit 1
+  echo "username or sudo command not found"
+  for package in $packages
+  do
+    if command -v "rpm" >/dev/null; then
+      if command rpm -q "$package" > /dev/null; then
+        continue
+      fi
+    fi
+    if command -v "dpkg" >/dev/null; then
+      dpkg -s "$package"
+    fi
+  done
 fi;


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.

The handler was failing in the event that both dpkg and rpm were both installed


### Modifications
#### Change summary

The verify-packages-installed handler will fail if both rpm and dpkg are installed. This fixes that.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
Passed integration tests successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
