### PR TITLE
Upgrade openssl version to 1.1.1n to address CVE-2022-0778

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -111,10 +111,10 @@ case $compileMode in
     apt-get install --assume-yes g++-arm-linux-gnueabihf
     apt-get install --assume-yes gcc-arm-linux-gnueabihf
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-1.1.1.tar.gz
-    tar -xvzf openssl-1.1.1.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+    tar -xvzf openssl-1.1.1n.tar.gz
     export INSTALL_DIR=/usr/lib/arm-linux-gnueabihf
-    cd openssl-1.1.1
+    cd openssl-1.1.1n
     ./Configure linux-generic32 shared \
       --prefix=$INSTALL_DIR --openssldir=$INSTALL_DIR/openssl \
       --cross-compile-prefix=/usr/bin/arm-linux-gnueabihf-
@@ -149,10 +149,10 @@ case $compileMode in
     apt-get install --assume-yes g++-mips-linux-gnu
     apt-get install --assume-yes gcc-mips-linux-gnu
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-1.1.1.tar.gz
-    tar -xvzf openssl-1.1.1.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+    tar -xvzf openssl-1.1.1n.tar.gz
     export INSTALL_DIR=/usr/lib/mips-linux-gnu
-    cd openssl-1.1.1
+    cd openssl-1.1.1n
     ./Configure linux-mips32 shared \
       --prefix=$INSTALL_DIR --openssldir=$INSTALL_DIR/openssl \
       --cross-compile-prefix=/usr/bin/mips-linux-gnu-
@@ -182,10 +182,10 @@ case $compileMode in
     apt-get install --assume-yes g++-aarch64-linux-gnu
     apt-get install --assume-yes gcc-aarch64-linux-gnu
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-1.1.1.tar.gz
-    tar -xvzf openssl-1.1.1.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+    tar -xvzf openssl-1.1.1n.tar.gz
     export INSTALL_DIR=/usr/lib/aarch64-linux-gnu
-    cd openssl-1.1.1
+    cd openssl-1.1.1n
     ./Configure linux-aarch64 shared \
       --prefix=$INSTALL_DIR --openssldir=$INSTALL_DIR/openssl \
       --cross-compile-prefix=/usr/bin/aarch64-linux-gnu-

--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -31,9 +31,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Install OpenSSL 1.1.1
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://www.openssl.org/source/openssl-1.1.1i.tar.gz \
-    && tar -zxvf openssl-1.1.1i.tar.gz \
-    && cd openssl-1.1.1i \
+RUN wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz \
+    && tar -zxvf openssl-1.1.1n.tar.gz \
+    && cd openssl-1.1.1n \
     && ./config \
     && make \
     && sudo make install
@@ -60,7 +60,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 15bb0b2123b0ab0a85e866c6e8d5b2713a923370 \
+    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -32,9 +32,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Install OpenSSL 1.1.1
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://www.openssl.org/source/openssl-1.1.1i.tar.gz \
-    && tar -zxvf openssl-1.1.1i.tar.gz \
-    && cd openssl-1.1.1i \
+RUN wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz \
+    && tar -zxvf openssl-1.1.1n.tar.gz \
+    && cd openssl-1.1.1n \
     && ./config \
     && make \
     && sudo make install
@@ -61,7 +61,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 15bb0b2123b0ab0a85e866c6e8d5b2713a923370 \
+    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update -qq \
 # Install OpenSSL 1.1.1
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://www.openssl.org/source/openssl-1.1.1.tar.gz \
-    && tar -zxvf openssl-1.1.1.tar.gz \
-    && cd openssl-1.1.1 \
+RUN wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz \
+    && tar -zxvf openssl-1.1.1n.tar.gz \
+    && cd openssl-1.1.1n \
     && ./config \
     && make \
     && make install \
@@ -57,7 +57,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 15bb0b2123b0ab0a85e866c6e8d5b2713a923370 \
+    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/cmake-toolchain/README.md
+++ b/cmake-toolchain/README.md
@@ -23,10 +23,10 @@ cmake ../ -DCMAKE_TOOLCHAIN_FILE=<Path/To/Build/Toolchain/File>
 ```
 The last dependency you'll need cross compiled is **openssl**.  This one is slightly more complicated but can be done as follows:  *(This example is from our build process, replace the information in carets.  While we happen to be linking against OpenSSL 1.1.1 in this example since our target device uses OpenSSL 1.1.1 for its TLS implementation, you'll want to replace this with whatever TLS implementation is present on your target device.)*
 ```
-wget https://www.openssl.org/source/openssl-1.1.1.tar.gz
-tar -xvzf openssl-1.1.1.tar.gz
+wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+tar -xvzf openssl-1.1.1n.tar.gz
 export INSTALL_DIR=</Path/To/Install/Dir>
-cd openssl-1.1.1
+cd openssl-1.1.1n
 ./Configure <Platform> shared \
     --prefix=$INSTALL_DIR --openssldir=$INSTALL_DIR/openssl \
     --cross-compile-prefix=</Compiler/Prefix/Path> 


### PR DESCRIPTION
### Motivation
- Upgrade openssl version to 1.1.1n to address CVE-2022-0778
- More details regard the vulnerabilities: https://www.openssl.org/news/secadv/20220315.txt


### Modifications
#### Change summary
Upgrade openssl version to 1.1.1n in the build file and dockerfile. 
Update the SDK commit hash in the dockerfile.
A separate PR will be submitted to upgrade the docker images. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
Build the device client with the latest sdk

- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
