### PR TITLE
Adds additional checks for packages

### DIFF
--- a/sample-job-handlers/verify-packages-installed.sh
+++ b/sample-job-handlers/verify-packages-installed.sh
@@ -8,28 +8,41 @@ packages=$@
 echo "Username: $user"
 echo "Packages to verify: $packages"
 
-if command -v "rpm" > /dev/null; then
+if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
   for package in $packages
   do
-    if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n rpm -q "$package"
-    else
-      echo "username or sudo command not found"
-      rpm -q "$package"
+    if command -v "rpm" >/dev/null; then
+      if command sudo -u "$user" -n rpm -q "$package" > /dev/null; then
+        continue
+      fi
     fi
-  done
-elif command -v "dpkg" > /dev/null; then
-  # Using -s flag instead of -l for dpkg based on https://github.com/bitrise-io/bitrise/issues/433
-  for package in $packages
-  do
-    if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n dpkg -s "$package"
-    else
-      echo "username or sudo command not found"
-      dpkg -s "$package"
+    if command -v "dpkg" >/dev/null; then
+      if sudo -u "$user" -n dpkg -s "$package"; then
+        continue
+      else
+        exit 1
+      fi
     fi
+    echo "No suitable package manager found"
+    exit 1
   done
 else
-  >&2 echo "No suitable package manager found"
-  exit 1
+  echo "username or sudo command not found"
+  for package in $packages
+  do
+    if command -v "rpm" >/dev/null; then
+      if command rpm -q "$package" >/dev/null; then
+        continue
+      fi
+    fi
+    if command -v "dpkg" >/dev/null; then
+      if command dpkg -s "$package" >/dev/null; then
+        continue
+      else
+        exit 1
+      fi
+    fi
+    echo "No suitable package manager found"
+    exit 1
+  done
 fi;

--- a/sample-job-handlers/verify-packages-installed.sh
+++ b/sample-job-handlers/verify-packages-installed.sh
@@ -19,8 +19,6 @@ if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
     if command -v "dpkg" >/dev/null; then
       if sudo -u "$user" -n dpkg -s "$package"; then
         continue
-      else
-        exit 1
       fi
     fi
     echo "No suitable package manager found"


### PR DESCRIPTION
### Motivation
Integration tests fail if multiple package managers installed


### Modifications
#### Change summary
Modifies verify packages installed script to check for packages with both rpm and dpkg.

### Testing
Ran Jobs integration tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
