### PR TITLE
Adds Permissions info to ST ReadMe

### DIFF
--- a/source/jobs/README.md
+++ b/source/jobs/README.md
@@ -456,7 +456,9 @@ Example:
 ### Policy Permissions
 In order to use the Jobs feature the device must first have permission to connect to IoT Core.
 The device must also be able to publish, subscribe, and receive messages on the Jobs MQTT topics.
-The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+The example policy below demonstrates the minimum permissions required for the Jobs feature. 
+Here we have left the JobId as a wildcard so any Job targeting the device can be run. 
+Replace the `<region>` and `<accountId`> with the correct values.
 ```
 {
   "Version": "2012-10-17",
@@ -464,53 +466,13 @@ The example policy below demonstrates the minimum permissions required. Simply r
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
-      ]
+      "Resource": "arn:aws:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "iot:Publish"
-      ],
+      "Action": "iot:Publish",
       "Resource": [
-        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Subscribe",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Receive",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Subscribe",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Receive",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Publish"
-      ],
-      "Resource": [
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next",
         "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update"
       ]
     },
@@ -518,37 +480,24 @@ The example policy below demonstrates the minimum permissions required. Simply r
       "Effect": "Allow",
       "Action": "iot:Subscribe",
       "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted"
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted",
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected",
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted",
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected",
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/jobs/notify-next"
       ]
     },
     {
       "Effect": "Allow",
       "Action": "iot:Receive",
       "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted"
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted",
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected",
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted",
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected",
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/notify-next"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Subscribe",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Receive",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "iot:Subscribe",
-      "Resource": [
-      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/notify-next"
-      ]
-    },
+    }
   ]
 }
 ```

--- a/source/jobs/README.md
+++ b/source/jobs/README.md
@@ -12,6 +12,7 @@
     + [Jobs Feature Configuration Options](#jobs-feature-configuration-options)
       - [Configuring the Jobs feature via the command line](#configuring-the-jobs-feature-via-the-command-line)
       - [Configuring the Jobs feature via the JSON configuration file](#configuring-the-jobs-feature-via-the-json-configuration-file)
+    + [Policy Permissions](#policy-permissions)
 
 [*Back To The Main Readme*](../../README.md)
 
@@ -450,6 +451,106 @@ Example:
         }
         ...
     }
+```
+
+### Policy Permissions
+In order to use the Jobs feature the device must first have permission to connect to IoT Core.
+The device must also be able to publish, subscribe, and receive messages on the Jobs MQTT topics.
+The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iot:Connect",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/start-next/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/*/update/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/jobs/notify-next"
+      ]
+    },
+  ]
+}
 ```
 
 [*Back To The Top*](#jobs)

--- a/source/shadow/README.md
+++ b/source/shadow/README.md
@@ -48,7 +48,8 @@ Device Client would also perform configuration validation check when detecting t
 ### Policy Permissions
 In order to use the Shadow feature the device must first have permission to connect to IoT Core.
 The device must also be able to publish, subscribe, and receive messages on the Shadow topics. You can read more [here](https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html).
-The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+The example policy below demonstrates the minimum permissions required for the Named Shadow feature. 
+Replace the `<region>`, `<accountId`> and `<shadowName>` with the correct values.
 ```
 {
   "Version": "2012-10-17",
@@ -56,116 +57,28 @@ The example policy below demonstrates the minimum permissions required. Simply r
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
+      "Resource": "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Publish",
       "Resource": [
-      "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/name/<shadowName>/get",
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/name/<shadowName>/update"
       ]
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "iot:Publish"
-      ],
+      "Action": "iot:Subscribe",
       "Resource": [
-        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get"
+        "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/name/<shadowName>*"
       ]
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
+      "Action": "iot:Receive",
       "Resource": [
-        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Publish"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/accepted"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/rejected"
-      ]
-    }
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/delta"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/delta"
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/name/<shadowName>/*"
       ]
     }
   ]

--- a/source/shadow/README.md
+++ b/source/shadow/README.md
@@ -45,4 +45,130 @@ Device Client would also perform configuration validation check when detecting t
 ```
 *It is important to note that providing input and output files is optional.  If they are not configured or left blank, "{welcome","aws-iot}" will be published to this shadow and the `default-sample-shadow-document`file will be created under this path `~/.aws-iot-device-client/sample-shadow/` by default*
 
+### Policy Permissions
+In order to use the Shadow feature the device must first have permission to connect to IoT Core.
+The device must also be able to publish, subscribe, and receive messages on the Shadow topics. You can read more [here](https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html).
+The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iot:Connect",
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/get/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/accepted"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/rejected"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/rejected"
+      ]
+    }
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/delta"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<region>:<account>:topic/$aws/things/${iot:Connection.Thing.ThingName}/shadow/update/delta"
+      ]
+    }
+  ]
+}
+```
 [*Back To The Top*](#Shadow_Feature)

--- a/source/tunneling/README.md
+++ b/source/tunneling/README.md
@@ -6,6 +6,7 @@
       - [Configuring the Secure Tunneling feature via the command line](#configuring-the-secure-tunneling-feature-via-the-command-line)
       - [Configuring the Secure Tunneling feature via the JSON configuration file](#configuring-the-secure-tunneling-feature-via-the-json-configuration-file)
     + [Example steps to use the Secure Tunneling feature](#example-steps-to-use-the-secure-tunneling-feature)
+    + [Policy Permissions](#policy-permissions)
     + [Limitation](#limitation)
 
 [*Back To The Main Readme*](../../README.md)
@@ -53,6 +54,34 @@ $ ./localproxy -r us-east-1 -s 8080 -t <source token>
 4. Start the SSH client but connect to the local proxy listening port. For example:
 ```
 $ ssh -p 8080 <remote_user_name>@localhost
+```
+
+### Policy Permissions
+In order to use the Secure Tunneling feature the device must first have permission to connect to IoT Core. 
+The device must also be able to subscribe to and receive messages on the Secure Tunneling notify topic in order to receive the destination token.
+The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iot:Connect",
+      "Resource": "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+    },
+
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+    }
+  ]
+}
 ```
 
 ### Limitation

--- a/source/tunneling/README.md
+++ b/source/tunneling/README.md
@@ -59,7 +59,7 @@ $ ssh -p 8080 <remote_user_name>@localhost
 ### Policy Permissions
 In order to use the Secure Tunneling feature the device must first have permission to connect to IoT Core. 
 The device must also be able to subscribe to and receive messages on the Secure Tunneling notify topic in order to receive the destination token.
-The example policy below demonstrates the minimum permissions required. Simply replace the `<region>` and `<accountId`> with the correct values.
+The example policy below demonstrates the minimum permissions required to run the Secure Tunneling feature. Simply replace the `<region>` and `<accountId`> with the correct values.
 ```
 {
   "Version": "2012-10-17",

--- a/source/tunneling/README.md
+++ b/source/tunneling/README.md
@@ -67,18 +67,24 @@ The example policy below demonstrates the minimum permissions required. Simply r
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:client/${iot:Connection.Thing.ThingName}"
+      ]
     },
 
     {
       "Effect": "Allow",
       "Action": "iot:Subscribe",
-      "Resource": "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topicfilter/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+      ]
     },
     {
       "Effect": "Allow",
       "Action": "iot:Receive",
-      "Resource": "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+      "Resource": [
+      "arn:aws:iot:<region>:<accountId>:topic/$aws/things/${iot:Connection.Thing.ThingName}/tunnels/notify"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
We were lacking an explanation of the necessary permissions to use secure tunneling.


### Modifications
#### Change summary
Adds details about the required permissions to the ReadMe.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
