### PR TITLE
Modifies Download-File handler

### DIFF
--- a/sample-job-handlers/download-file.sh
+++ b/sample-job-handlers/download-file.sh
@@ -12,10 +12,18 @@ if command -v "wget" > /dev/null
 then
     echo "Using wget for downloading user specified file"
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
-      sudo -u "$user" -n wget --quiet -O "$outputFile" "$fileUrl"
+      if [ -d "$outputFile" ]; then
+        sudo -u "$user" -n wget --quiet -P "$outputFile" "$fileUrl"
+      else
+        sudo -u "$user" -n wget --quiet -O "$outputFile" "$fileUrl"
+      fi
     else
       echo "username or sudo command not found"
-      wget --quiet -O "$outputFile" "$fileUrl"
+      if [ -d "$outputFile" ]; then
+        wget --quiet -P "$outputFile" "$fileUrl"
+      else
+        wget --quiet -O "$outputFile" "$fileUrl"
+      fi
     fi
 else
     >&2 echo "Wget software package not installed on the device. Use the \"install-packages.sh\" operation to install the wget software package on this device."


### PR DESCRIPTION
### Motivation
The Job would fail when customers passed a directory for the destination of a Download File action. This change allows a directory to be used as the destination file.


### Modifications
#### Change summary
The Download File handler will now check if the file passed as destination is a directory and if so will place the file in that directory.

### Testing
Manually tested via the console.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
