### PR TITLE
Fix a minor memory leak and make tests valgrind clean

### DIFF
--- a/source/logging/Logger.h
+++ b/source/logging/Logger.h
@@ -80,6 +80,9 @@ namespace Aws
                     void setLogLevel(int level) { logLevel = level; }
 
                   public:
+                    // Logger inherited by FileLogger. Make destructor virtual to avoid memory leak.
+                    virtual ~Logger() = default;
+
                     /**
                      * \brief Formats the provided log message against variadic arguments and then
                      * passes the message to the underlying logger implementation for processing

--- a/test/util/TestFileUtils.cpp
+++ b/test/util/TestFileUtils.cpp
@@ -336,6 +336,7 @@ TEST(FileUtils, byteBufReadWrite)
     {
         ASSERT_EQ((uint8_t)someData[i], readDataByteBuf.buffer[i]);
     }
+    aws_byte_buf_clean_up(&readDataByteBuf);
     remove(filePath.c_str());
 }
 
@@ -358,6 +359,7 @@ TEST(FileUtils, byteBufReadWriteAppend)
     {
         ASSERT_EQ((uint8_t)someData[i], readDataByteBuf.buffer[i]);
     }
+    aws_byte_buf_clean_up(&readDataByteBuf);
     remove(filePath.c_str());
 }
 
@@ -369,6 +371,7 @@ TEST(FileUtils, byteBufReadSizeLargerThanBuffer)
     aws_byte_buf_init(&readDataByteBuf, aws_default_allocator(), 10);
 
     ASSERT_EQ(-1, FileUtils::ReadFromFile(filePath, &readDataByteBuf, 500));
+    aws_byte_buf_clean_up(&readDataByteBuf);
 }
 
 TEST(FileUtils, byteBufReadNonexistentFile)
@@ -378,6 +381,7 @@ TEST(FileUtils, byteBufReadNonexistentFile)
     aws_byte_buf readDataByteBuf;
     aws_byte_buf_init(&readDataByteBuf, aws_default_allocator(), 1);
     ASSERT_EQ(-1, FileUtils::ReadFromFile(filePath, &readDataByteBuf, 1));
+    aws_byte_buf_clean_up(&readDataByteBuf);
 }
 
 TEST(FileUtils, IsValidFilePathForFileExistence)


### PR DESCRIPTION
### Motivation
Some of our existing unit tests that are not valgrind clean.

### Modifications
#### Change summary
 This PR makes the tests valgrind clean (see before and after snippets pasted below) and fixes a real memory leak in FileLogger.

### Testing

Before.

```
root@462ca6854276:/src/build-debug# valgrind --leak-check=yes ./test/test-aws-iot-device-client
...
==714==
==714== HEAP SUMMARY:
==714==     in use at exit: 2,360 bytes in 14 blocks
==714==   total heap usage: 5,100 allocs, 5,086 frees, 1,295,537 bytes allocated
...
==714== LEAK SUMMARY:
==714==    definitely lost: 632 bytes in 8 blocks
==714==    indirectly lost: 1,728 bytes in 6 blocks
==714==      possibly lost: 0 bytes in 0 blocks
==714==    still reachable: 0 bytes in 0 blocks
==714==         suppressed: 0 bytes in 0 blocks
==714==
==714== For lists of detected and suppressed errors, rerun with: -s
==714== ERROR SUMMARY: 8 errors from 8 contexts (suppressed: 0 from 0)
```

After.

```
root@462ca6854276:/src/build-debug# valgrind --leak-check=yes ./test/test-aws-iot-device-client
==433== Memcheck, a memory error detector
==433== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==433== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==433== Command: ./test/test-aws-iot-device-client
==433==
...
==433==
==433== HEAP SUMMARY:
==433==     in use at exit: 0 bytes in 0 blocks
==433==   total heap usage: 5,100 allocs, 5,100 frees, 1,295,537 bytes allocated
==433==
==433== All heap blocks were freed -- no leaks are possible
==433==
==433== For lists of detected and suppressed errors, rerun with: -s
==433== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
