### PR TITLE
Patch version should count commits from head of current branch instea…

### DIFF
--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -26,7 +26,7 @@ if (GIT_VERSION AND NOT ${GIT_INFO} STREQUAL "")
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     # Determine how many commits since last tag
-    execute_process(COMMAND ${GIT_EXECUTABLE} rev-list origin/main ${${PROJECT_NAME}_VERSION_STRING}..HEAD --count
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-list ${${PROJECT_NAME}_VERSION_STRING}..HEAD --count
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_AHEAD
         OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
…d of main

### Motivation
- Device client patch version number is intended to count commits from the most recent tag.
- A bug in how the patch version is computed will result in incorrect patch version when building device client on a branch other than `main`.

### Modifications
#### Change summary
Currently we use the following command to count the number of commits from the patch release, notice that we are counting relative to origin/main 
```
git rev-list origin/main $(MAJOR).$(MINOR)..HEAD --count
```
Instead we should drop `origin/main` when counting commits.
```
git rev-list $(MAJOR).$(MINOR)..HEAD --count
````

### Testing
- Example demonstrating the problem. 
```
# Checkout commit `b6080e5bbf89fca176372aa7c839cd8e92edf7dc` on feature branch named `version-v1.5.13`
$ git checkout -b version-v1.5.13 b6080e5bbf89fca176372aa7c839cd8e92edf7dc 

# Confirm the checked out commit is 13 commits from previous tag v1.5
$ git log -n 14 --pretty=oneline
b6080e5bbf89fca176372aa7c839cd8e92edf7dc (HEAD -> version-v1.5.13) Upgrade openssl version to 1.1.1n to address CVE-2022-0778 (#228)
5a2ee9fd9073ffffc5640e4f60986403a0d64adb Adds retryable and non-retryable errors for UpdateJobExecutionStatus (#226)
6a45e9264266401f0648ecb01deecbfa3a454ef2 Fixes bug in setup script (#221)
f6a96dfbac90a232a4b669897c7a62852bf60438 Updated DD code to subscribe & unsubscribe to `/rejected` topic (#224)
5cc4d24a5f4b9d93ea775184ed8ecabf5c775c77 Fix fleet-provisioning key in Config::ExportDefaultSetting (#222)
2d1ec51f223e7946b8da9d5330d588b6c4f387a2 Use AWS_CRT_MEMORY_TRACING to enable memory trace (#220)
21dad860edc17bb0ea3b6dd0567e96ccf7e030a5 Switch to cross-platform limits.h (#216)
0b2f2df5a82ca26846266283935fc5508eb01b88 Update SDK with secure tunneling deadlock fix (#219)
817cd3a32179f50fdde5af90f350a0c23de2be7e Bug fix for pub sub creation (#214)
2790c41a954f38119cd3c87015ecf77aec28dbc8 Device Client bug fixes for (1)reboot action, (2)Docker images and (3)DC versioning  (#210)
7755cfcd8f30e33443d7204d6115122923db6d33 Patch secure tunneling bug in aws-c-iot (#209)
1d2da93760daa503f0196642b3e01cb71f55a958 Updated github workflow to trigger doxygen update on merge event (#207)
ea12a7dfade52357d043a8c41bebbb787d48cce5 v1.5 Release of the Device Client (#206)
e9691f753ec36f4b20fd88897a804586818bf704 (tag: v1.5) enabled dir creation in setup.sh and dir/file creation in pubsub.cpp (#204)

# Current method in version script counts 19 commits relative to main
$ git rev-list origin/main v1.5..HEAD --count
19

# Proposed fix to the version script counts 13 commits from current branch
$ git rev-list  v1.5..HEAD --count
13
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
