### PR TITLE
Fix logging race condition

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -233,3 +233,4 @@ cmake --build . --target test-aws-iot-device-client
 
 ### Run Tests ###
 env AWS_CRT_MEMORY_TRACING=1 ./test/test-aws-iot-device-client
+./test/test-aws-iot-device-client --gtest_filter=LogQueueTest.notifyAllOnShutdown --gtest_repeat=1000

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -25,8 +25,7 @@ std::unique_ptr<LogMessage> LogQueue::getNextLog()
     unique_lock<mutex> readLock(queueLock);
     while (logQueue.empty() && !isShutdown)
     {
-        newLogNotifier.wait(readLock);
-        // newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
+        newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
     }
     if (logQueue.empty())
     {

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<LogMessage> LogQueue::getNextLog()
     unique_lock<mutex> readLock(queueLock);
     while (logQueue.empty() && !isShutdown)
     {
-        newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
+        newLogNotifier.wait_for(readLock, chrono::milliseconds(100));
     }
     if (logQueue.empty())
     {

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<LogMessage> LogQueue::getNextLog()
     while (logQueue.empty() && !isShutdown)
     {
         newLogNotifier.wait(readLock);
-        //newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
+        // newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
     }
     if (logQueue.empty())
     {

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<LogMessage> LogQueue::getNextLog()
     unique_lock<mutex> readLock(queueLock);
     while (logQueue.empty() && !isShutdown)
     {
-        newLogNotifier.wait(readLock);
+        newLogNotifier.wait_for(readLock, chrono::seconds(1));
     }
     if (logQueue.empty())
     {

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -25,7 +25,8 @@ std::unique_ptr<LogMessage> LogQueue::getNextLog()
     unique_lock<mutex> readLock(queueLock);
     while (logQueue.empty() && !isShutdown)
     {
-        newLogNotifier.wait_for(readLock, chrono::seconds(1));
+        newLogNotifier.wait(readLock);
+        //newLogNotifier.wait_for(readLock, chrono::milliseconds (100));
     }
     if (logQueue.empty())
     {

--- a/source/logging/LogQueue.cpp
+++ b/source/logging/LogQueue.cpp
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "LogQueue.h"
+#include <iostream>
+#include <thread>
 
 using namespace std;
 using namespace Aws::Iot::DeviceClient::Logging;
+
+constexpr int LogQueue::EMPTY_WAIT_TIME_MILLISECONDS;
 
 void LogQueue::addLog(unique_ptr<LogMessage> log)
 {
@@ -23,10 +27,12 @@ bool LogQueue::hasNextLog()
 std::unique_ptr<LogMessage> LogQueue::getNextLog()
 {
     unique_lock<mutex> readLock(queueLock);
+
     while (logQueue.empty() && !isShutdown)
     {
-        newLogNotifier.wait_for(readLock, chrono::milliseconds(100));
+        newLogNotifier.wait_for(readLock, chrono::milliseconds(EMPTY_WAIT_TIME_MILLISECONDS));
     }
+
     if (logQueue.empty())
     {
         return NULL;

--- a/source/logging/LogQueue.h
+++ b/source/logging/LogQueue.h
@@ -5,6 +5,7 @@
 #define DEVICE_CLIENT_LOGQUEUE_H
 
 #include "LogMessage.h"
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -27,7 +28,12 @@ namespace Aws
                     /**
                      * \brief Whether the LogQueue has been shutdown or not.
                      */
-                    bool isShutdown = false;
+                    std::atomic<bool> isShutdown{false};
+                    /**
+                     * \brief The default value in milliseconds for which Device client will wait after blocking when
+                     * the queue is empty.
+                     */
+                    static constexpr int EMPTY_WAIT_TIME_MILLISECONDS = 200;
                     /**
                      * \brief a Mutex used to control multi-threaded access to the LogQueue
                      */

--- a/test/logging/TestLogQueue.cpp
+++ b/test/logging/TestLogQueue.cpp
@@ -85,8 +85,8 @@ TEST_F(LogQueueTest, notifyAllOnShutdown)
 
     logQueue->shutdown();
 
-    cv.wait_for(lock1, chrono::milliseconds(200));
-    cv2.wait_for(lock2, chrono::milliseconds(200));
+    cv.wait_for(lock1, chrono::milliseconds(400));
+    cv2.wait_for(lock2, chrono::milliseconds(400));
 
     ASSERT_TRUE(processed && processed2);
 }

--- a/test/logging/TestLogQueue.cpp
+++ b/test/logging/TestLogQueue.cpp
@@ -85,6 +85,7 @@ TEST_F(LogQueueTest, notifyAllOnShutdown)
 
     logQueue->shutdown();
 
+    // 400ms is 2 * EMPTY_WAIT_TIME_MILLISECONDS as defined in LogQueue.h
     cv.wait_for(lock1, chrono::milliseconds(400));
     cv2.wait_for(lock2, chrono::milliseconds(400));
 

--- a/test/logging/TestLogQueue.cpp
+++ b/test/logging/TestLogQueue.cpp
@@ -85,8 +85,8 @@ TEST_F(LogQueueTest, notifyAllOnShutdown)
 
     logQueue->shutdown();
 
-    cv.wait_for(lock1, chrono::seconds(1));
-    cv2.wait_for(lock2, chrono::seconds(1));
+    cv.wait_for(lock1, chrono::milliseconds (200));
+    cv2.wait_for(lock2, chrono::milliseconds(200));
 
     ASSERT_TRUE(processed && processed2);
 }

--- a/test/logging/TestLogQueue.cpp
+++ b/test/logging/TestLogQueue.cpp
@@ -85,7 +85,7 @@ TEST_F(LogQueueTest, notifyAllOnShutdown)
 
     logQueue->shutdown();
 
-    cv.wait_for(lock1, chrono::milliseconds (200));
+    cv.wait_for(lock1, chrono::milliseconds(200));
     cv2.wait_for(lock2, chrono::milliseconds(200));
 
     ASSERT_TRUE(processed && processed2);


### PR DESCRIPTION
### Motivation
- One of our unit tests has been failing due to a race condition bug in our logging code.

### Modifications
#### Change summary
replaced wait() with wait_for(), which establishes a maximum duration for the thread to unblock itself if the condition variable never gets notified.

### Testing
- tested via code tracing and lots of test runs, will need additional time to completely verify fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
