### PR TITLE
implemented max logging size

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1998,14 +1998,14 @@ bool Config::ParseConfigFile(const string &file, bool isRuntimeConfig)
     }
 
     size_t incomingFileSize = FileUtils::GetFileSize(file);
-    if (5000 < incomingFileSize)
+    if (incomingFileSize > Config::MAX_CONFIG_SIZE)
     {
         LOGM_WARN(
             TAG,
             "Refusing to open config file %s, file size %zu bytes is greater than allowable limit of %zu bytes",
             Sanitize(file).c_str(),
             incomingFileSize,
-            5000);
+            Config::MAX_CONFIG_SIZE);
         return false;
     }
 

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -415,6 +415,11 @@ namespace Aws
                 bool init(const CliArgs &cliArgs);
 
                 /**
+                 * \brief Maximum accepted size for the config file.
+                 */
+                static constexpr size_t MAX_CONFIG_SIZE = 5000;
+
+                /**
                  * \brief Separator between directories in path.
                  */
                 static constexpr char PATH_DIRECTORY_SEPARATOR = '/';

--- a/source/util/StringUtils.cpp
+++ b/source/util/StringUtils.cpp
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "StringUtils.h"
+#include "../config/Config.h"
 #include <cstdarg>
 #include <map>
-#include <sstream>
 
 using namespace std;
 
@@ -20,8 +20,12 @@ namespace Aws
                 {
                     va_list copy;
                     va_copy(copy, args);
-                    int formattedMsgSize = vsnprintf(nullptr, 0, message, copy) + 1;
+                    size_t formattedMsgSize = vsnprintf(nullptr, 0, message, copy);
                     va_end(copy);
+
+                    // will format up to MAX_CONFIG_SIZE, the maximum buffer size after which log messages will get
+                    // truncated
+                    formattedMsgSize = std::min(formattedMsgSize, Config::MAX_CONFIG_SIZE - 1) + 1;
 
                     std::string buffer;
                     buffer.resize(formattedMsgSize);

--- a/test/util/TestStringUtils.cpp
+++ b/test/util/TestStringUtils.cpp
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../../source/config/Config.h"
 #include "../../source/util/StringUtils.h"
 #include "gtest/gtest.h"
 
 using namespace std;
+using namespace Aws::Iot::DeviceClient;
 using namespace Aws::Iot::DeviceClient::Util;
+
+constexpr size_t Config::MAX_CONFIG_SIZE;
 
 TEST(StringUtils, FormatStringNoArg)
 {
@@ -19,6 +23,13 @@ TEST(StringUtils, FormatStringWithArg)
     constexpr char format[] = "I want to eat %d fresh %s.";
     string actual = FormatMessage(format, 1, "apple");
     ASSERT_STREQ("I want to eat 1 fresh apple.", actual.c_str());
+}
+
+TEST(StringUtils, FormatStringTruncate)
+{
+    string s(Config::MAX_CONFIG_SIZE + 1234, '*');
+    string actual = FormatMessage(s.c_str());
+    ASSERT_EQ(actual.size(), Config::MAX_CONFIG_SIZE);
 }
 
 TEST(StringUtils, sanitizeRemovesFormatSpecifier)


### PR DESCRIPTION
### Motivation

### Modifications
#### Change summary
Caps max logging message size to a certain value. However, we do log the entire config file on startup so that message will be truncated if the max buffer size is too small

Documentation about null terminated strings has already been done at an earlier time.