### PR TITLE
replace abort with exit

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -125,8 +125,7 @@ void shutdown()
 }
 
 /**
- * \brief This function is a wrapper around abort() which makes sure we let the user know
- * that we are aborting execution due to some type of configuration issue
+ * \brief This function shuts down device client when aborting execution due to some type of configuration issue
  *
  * @param reason the reason why the abort is happening
  */
@@ -134,7 +133,7 @@ void deviceClientAbort(string reason)
 {
     cout << "AWS IoT Device Client must abort execution, reason: " << reason << endl;
     cout << "Please check the AWS IoT Device Client logs for more information" << endl;
-    abort();
+    exit(EXIT_FAILURE);
 }
 
 void handle_feature_stopped(Feature *feature)


### PR DESCRIPTION
### Motivation

### Modifications
#### Change summary
- From cppreference, calling exit() allows for: "Objects with static storage duration are destroyed (C++) and functions registered with atexit are called."
- Replacing abort() with shutdown() is not possible because of segmentation fault of the resource manager if called before we attempt the mqtt connection.
- Performed a global search of the source code and no other calls to abort() were made.

### Testing
- manually tested by calling deviceClientAbort at different places 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
