### PR TITLE
Enable cppcheck as part of build

### DIFF
--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -19,6 +19,15 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 ###############################################################################
+# Install cppcheck
+# cppcheck package is not available from amazonlinux default repositories
+# Install and enable epel repository.
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
+###############################################################################
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum --enablerepo=epel install -y cppcheck
+
+###############################################################################
 # Install pre-built CMake
 ###############################################################################
 WORKDIR /tmp

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -20,6 +20,15 @@ RUN yum --disableplugin=subscription-manager -y update \
     && rm -rf /var/cache/yum
 
 ###############################################################################
+# Install cppcheck
+# cppcheck package is not available from amazonlinux default repositories
+# Install and enable epel repository.
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-repositories.html
+###############################################################################
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum --enablerepo=epel install -y cppcheck
+
+###############################################################################
 # Install pre-built CMake
 ###############################################################################
 WORKDIR /tmp

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -qq \
     curl \
     build-essential \
     wget \
+    cppcheck \
     && apt-get clean
 
 ###############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE
-      - name: Archive ubuntu-16-x64 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
+      - name: Archive ubuntu-16-x64 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
         if: github.ref == 'refs/heads/main'
-        with:                                                                                                                                                                                                 
+        with:
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.static"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive setup files
         uses: actions/upload-artifact@v2
@@ -79,11 +79,11 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/amazonlinux:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/amazonlinux:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE
-  
+
   build-rhel-ubi8:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
@@ -93,17 +93,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubi8:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubi8:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE
-      - name: Archive rhel-ubi8 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive rhel-ubi8 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}.static"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive setup files
         uses: actions/upload-artifact@v2
@@ -126,8 +126,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compiler=g++-${{ matrix.version }}
 
@@ -143,8 +143,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compiler=clang-${{ matrix.version }}
 
@@ -157,17 +157,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=armhf_cross_mode
-      - name: Archive armhf32 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive armhf32 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}.static"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive setup files
         uses: actions/upload-artifact@v2
@@ -187,17 +187,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=mips_cross_mode
-      - name: Archive mips32 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive mips32 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}.static"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive setup files
         uses: actions/upload-artifact@v2
@@ -217,17 +217,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=aarch64_cross_mode
-      - name: Archive aarch64 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive aarch64 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}.static"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive setup files
         uses: actions/upload-artifact@v2
@@ -247,17 +247,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=shared_lib_mode
-      - name: Archive ubuntu-16-x64 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
+      - name: Archive ubuntu-16-x64 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
         if: github.ref == 'refs/heads/main'
-        with:                                                                                                                                                                                                 
-          name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.shared"                                                                                                                          
-          path: |                                                                                                                                                                                             
+        with:
+          name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.shared"
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive SDK shared libraries
         uses: actions/upload-artifact@v2
@@ -275,7 +275,7 @@ jobs:
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.shared"
           path: |
             ./setup/
-  
+
   build-shared-libs-amazonlinux:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
@@ -285,8 +285,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/amazonlinux:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/amazonlinux:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=shared_lib_mode
 
@@ -296,20 +296,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0      
+          fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubi8:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubi8:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=shared_lib_mode
-      - name: Archive rhel-ubi8 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive rhel-ubi8 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}.shared"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive SDK shared libraries
         uses: actions/upload-artifact@v2
@@ -337,17 +337,17 @@ jobs:
             fetch-depth: 0
         - name: Build ${{ env.PACKAGE_NAME }}
           run: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-            export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+            export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
             docker pull $DOCKER_IMAGE
             docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=armhf_cross_mode_shared_libs
-        - name: Archive armhf32 Build Artifact                                                                                                                                                        
-          uses: actions/upload-artifact@v2                                                                                                                                                                      
-          # Run for main branch only                                                                                                                                                                            
-          if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-          with:                                                                                                                                                                                                 
+        - name: Archive armhf32 Build Artifact
+          uses: actions/upload-artifact@v2
+          # Run for main branch only
+          if: github.ref == 'refs/heads/main'
+          with:
             name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}.shared"
-            path: |                                                                                                                                                                                             
+            path: |
               ./build/${{ env.PACKAGE_NAME }}
         - name: Archive SDK shared libraries
           uses: actions/upload-artifact@v2
@@ -375,17 +375,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=mips_cross_mode_shared_libs
-      - name: Archive mips32 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive mips32 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}.shared"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive SDK shared libraries
         uses: actions/upload-artifact@v2
@@ -413,17 +413,17 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=aarch64_cross_mode_shared_libs
-      - name: Archive aarch64 Build Artifact                                                                                                                                                        
-        uses: actions/upload-artifact@v2                                                                                                                                                                      
-        # Run for main branch only                                                                                                                                                                            
-        if: github.ref == 'refs/heads/main'                                                                                                                                                                   
-        with:                                                                                                                                                                                                 
+      - name: Archive aarch64 Build Artifact
+        uses: actions/upload-artifact@v2
+        # Run for main branch only
+        if: github.ref == 'refs/heads/main'
+        with:
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}.shared"
-          path: |                                                                                                                                                                                             
+          path: |
             ./build/${{ env.PACKAGE_NAME }}
       - name: Archive SDK shared libraries
         uses: actions/upload-artifact@v2
@@ -451,8 +451,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }} ST Component Mode
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_component_mode
       - name: Archive ST Component Mode Build Artifact
@@ -473,8 +473,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_aarch64_cross_mode
       - name: Archive ST Ubuntu aarch64 Build Artifact
@@ -495,8 +495,8 @@ jobs:
           fetch-depth: 0
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_armhf_cross_mode
       - name: Archive st armhf32 Build Artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,21 @@ else ()
     link_directories(/lib)
 endif ()
 
+#########################################
+# cppcheck                              #
+#########################################
+option(ENABLE_CPPCHECK "Enable static analysis with cppcheck" ON)
+
+if (ENABLE_CPPCHECK)
+    find_program(CPPCHECK cppcheck)
+    if (CPPCHECK)
+        # Run cppcheck on source files, excluding test subdirectory and build dependencies.
+        set(CMAKE_CXX_CPPCHECK ${CPPCHECK} --enable=all --suppress=missingIncludeSystem --suppress=preprocessorErrorDirective -i ${CMAKE_CURRENT_SOURCE_DIR}/test)
+    else()
+        message(SEND_ERROR "cppcheck executable not found")
+    endif()
+endif()
+
 ###############################################
 ## Build the AWS IoT Device Client Executable #
 ###############################################


### PR DESCRIPTION
### Motivation
- Add static analysis check to the build.

### Modifications
#### Change summary
- Add cppcheck to the base image.
- Run cppcheck on source files, excluding test subdirectory and build dependencies.

### Testing
- Unit tests only


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
