### PR TITLE
Fix compile error for Musl C

### DIFF
--- a/source/util/FileUtils.h
+++ b/source/util/FileUtils.h
@@ -6,6 +6,7 @@
 
 #include <aws/common/byte_buf.h>
 #include <string>
+#include <sys/stat.h>
 
 namespace Aws
 {


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/186


### Modifications
#### Change summary
In file `source/util/FileUtils.h` it uses `mode_t` in https://github.com/awslabs/aws-iot-device-client/blob/191c842e9c2a053ffa0be4e450cdf71cc36ccfbb/source/util/FileUtils.h#L118 without including necessary header and cause compile error in Musl-C toolchain. It can be fixed by including necessary header `sys/stat.h`.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
I compiled it with Musl-C toolchain and verified it by running it on OpenWRT device with Musl-C runtime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
