### PR TITLE
Root ca

### DIFF
--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -36,10 +36,7 @@ namespace Aws
                     mOnConnectionShutdown = onConnectionShutdown;
                 }
 
-                SecureTunnelingContext::~SecureTunnelingContext()
-                {
-                    mSecureTunnel->Close();
-                }
+                SecureTunnelingContext::~SecureTunnelingContext() { mSecureTunnel->Close(); }
 
                 template <typename T>
                 static bool operator==(const Aws::Crt::Optional<T> &lhs, const Aws::Crt::Optional<T> &rhs)
@@ -110,7 +107,8 @@ namespace Aws
                         bind(&SecureTunnelingContext::OnStreamReset, this),
                         bind(&SecureTunnelingContext::OnSessionReset, this)));
 
-                    bool success = mSecureTunnel->GetUnderlyingHandle() != nullptr && mSecureTunnel->Connect() == AWS_OP_SUCCESS;
+                    bool success =
+                        mSecureTunnel->GetUnderlyingHandle() != nullptr && mSecureTunnel->Connect() == AWS_OP_SUCCESS;
                     if (!success)
                     {
                         LOG_ERROR(TAG, "Cannot connect to secure tunnel. Please see the SDK log for detail.");

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -38,10 +38,7 @@ namespace Aws
 
                 SecureTunnelingContext::~SecureTunnelingContext()
                 {
-                    if(mSecureTunnel->GetUnderlyingHandle() != nullptr)
-                    {
-                        mSecureTunnel->Close();
-                    }
+                    mSecureTunnel->Close();
                 }
 
                 template <typename T>

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -22,18 +22,15 @@ namespace Aws
 
                 SecureTunnelingContext::SecureTunnelingContext(
                     shared_ptr<SharedCrtResourceManager> manager,
-                    Aws::Crt::Optional<std::string> &rootCa,
+                    const Aws::Crt::Optional<std::string> &rootCa,
                     const string &accessToken,
                     const string &endpoint,
                     uint16_t port,
-                    OnConnectionShutdownFn onConnectionShutdown)
+                    const OnConnectionShutdownFn &onConnectionShutdown)
+                    : mSharedCrtResourceManager(manager), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
+                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port),
+                      mOnConnectionShutdown(onConnectionShutdown)
                 {
-                    mSharedCrtResourceManager = manager;
-                    mRootCa = rootCa.has_value() ? rootCa.value() : basic_string<char>("");
-                    mAccessToken = accessToken;
-                    mEndpoint = endpoint;
-                    mPort = port;
-                    mOnConnectionShutdown = onConnectionShutdown;
                 }
 
                 SecureTunnelingContext::~SecureTunnelingContext() { mSecureTunnel->Close(); }
@@ -107,13 +104,13 @@ namespace Aws
                         bind(&SecureTunnelingContext::OnStreamReset, this),
                         bind(&SecureTunnelingContext::OnSessionReset, this)));
 
-                    bool success =
+                    bool connectionSuccess =
                         mSecureTunnel->GetUnderlyingHandle() != nullptr && mSecureTunnel->Connect() == AWS_OP_SUCCESS;
-                    if (!success)
+                    if (!connectionSuccess)
                     {
                         LOG_ERROR(TAG, "Cannot connect to secure tunnel. Please see the SDK log for detail.");
                     }
-                    return success;
+                    return connectionSuccess;
                 }
 
                 void SecureTunnelingContext::ConnectToTcpForward()

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -83,7 +83,7 @@ namespace Aws
                         return false;
                     }
 
-                    if(mEndpoint.empty())
+                    if (mEndpoint.empty())
                     {
                         LOG_ERROR(TAG, "Cannot connect to secure tunnel. Endpoint is missing.");
                         return false;

--- a/source/tunneling/SecureTunnelingContext.h
+++ b/source/tunneling/SecureTunnelingContext.h
@@ -40,7 +40,7 @@ namespace Aws
                      */
                     SecureTunnelingContext(
                         std::shared_ptr<SharedCrtResourceManager> manager,
-                        const std::string &rootCa,
+                        Aws::Crt::Optional<std::string> &rootCa,
                         const std::string &accessToken,
                         const std::string &endpoint,
                         uint16_t port,

--- a/source/tunneling/SecureTunnelingContext.h
+++ b/source/tunneling/SecureTunnelingContext.h
@@ -40,11 +40,11 @@ namespace Aws
                      */
                     SecureTunnelingContext(
                         std::shared_ptr<SharedCrtResourceManager> manager,
-                        Aws::Crt::Optional<std::string> &rootCa,
+                        const Aws::Crt::Optional<std::string> &rootCa,
                         const std::string &accessToken,
                         const std::string &endpoint,
                         uint16_t port,
-                        OnConnectionShutdownFn onConnectionShutdown);
+                        const OnConnectionShutdownFn &onConnectionShutdown);
 
                     /**
                      * \brief Destructor

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -95,7 +95,7 @@ namespace Aws
                 void SecureTunnelingFeature::LoadFromConfig(const PlainConfig &config)
                 {
                     mThingName = *config.thingName;
-                    mRootCa = *config.rootCa;
+                    mRootCa = config.rootCa;
                     mSubscribeNotification = config.tunneling.subscribeNotification;
                     mEndpoint = config.tunneling.endpoint;
 
@@ -104,7 +104,7 @@ namespace Aws
                         std::unique_ptr<SecureTunnelingContext> context =
                             unique_ptr<SecureTunnelingContext>(new SecureTunnelingContext(
                                 mSharedCrtResourceManager,
-                                *config.rootCa,
+                                mRootCa,
                                 *config.tunneling.destinationAccessToken,
                                 GetEndpoint(*config.tunneling.region),
                                 static_cast<uint16_t>(config.tunneling.port.value()),

--- a/source/tunneling/SecureTunnelingFeature.h
+++ b/source/tunneling/SecureTunnelingFeature.h
@@ -166,7 +166,7 @@ namespace Aws
                     /**
                      * \brief Path to the Amazon root CA
                      */
-                    std::string mRootCa;
+                     Aws::Crt::Optional<std::string> mRootCa;
 
                     /**
                      * \brief Should the Secure Tunneling feature subscribe to MQTT new tunnel notification?

--- a/source/tunneling/SecureTunnelingFeature.h
+++ b/source/tunneling/SecureTunnelingFeature.h
@@ -166,7 +166,7 @@ namespace Aws
                     /**
                      * \brief Path to the Amazon root CA
                      */
-                     Aws::Crt::Optional<std::string> mRootCa;
+                    Aws::Crt::Optional<std::string> mRootCa;
 
                     /**
                      * \brief Should the Secure Tunneling feature subscribe to MQTT new tunnel notification?


### PR DESCRIPTION
### Motivation
The SDK changed such that a bad root-ca path would override the trust store. This change makes root-ca optional so that the SDK will default to trust store.

### Modifications
#### Change summary
Makes root-ca optional and adds a null check to ST connect method to prevent seg fault.

### Testing
Manually tested by opening and closing tunnels


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
