### PR TITLE
Enable valgrind as part of build

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -232,4 +232,4 @@ fi
 cmake --build . --target test-aws-iot-device-client
 
 ### Run Tests ###
-env AWS_CRT_MEMORY_TRACING=1 valgrind --leak-check=yes ./test/test-aws-iot-device-client
+env AWS_CRT_MEMORY_TRACING=1 valgrind --leak-check=yes --error-exitcode=1 ./test/test-aws-iot-device-client

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -232,5 +232,4 @@ fi
 cmake --build . --target test-aws-iot-device-client
 
 ### Run Tests ###
-env AWS_CRT_MEMORY_TRACING=1 ./test/test-aws-iot-device-client
-./test/test-aws-iot-device-client --gtest_filter=LogQueueTest.notifyAllOnShutdown --gtest_repeat=1000
+env AWS_CRT_MEMORY_TRACING=1 valgrind --leak-check=yes ./test/test-aws-iot-device-client

--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y update \
     make \
     gcc \
     gcc-c++ \
+    valgrind \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -8,6 +8,7 @@ ARG OPENSSL_VERSION=1.1.1n
 RUN yum -y update \
     && yum -y install \
     tar \
+    bzip2 \
     git \
     wget \
     curl \
@@ -15,7 +16,6 @@ RUN yum -y update \
     make \
     gcc \
     gcc-c++ \
-    valgrind \
     && yum clean all \
     && rm -rf /var/cache/yum
 
@@ -63,6 +63,17 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
     && cp -a googlemock/include/gmock /usr/include/ \
     && cp -a lib/* /usr/lib64/ \
     && rm -f /tmp/release-1.10.0.tar.gz
+
+###############################################################################
+# Clone and build valgrind
+###############################################################################
+WORKDIR /tmp
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 \
+    && tar jxvf valgrind-3.19.0.tar.bz2 \
+    && cd valgrind-3.19.0 \
+    && ./configure \
+    && make \
+    && make install
 
 # ###############################################################################
 # # Install Aws Iot Device Sdk Cpp v2

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -9,6 +9,7 @@ RUN subscription-manager config --rhsm.manage_repos=0
 RUN yum --disableplugin=subscription-manager -y update \
     && yum --disableplugin=subscription-manager -y install \
     tar \
+    bzip2 \
     git \
     wget \
     curl \
@@ -36,7 +37,7 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
     && tar -zxvf cmake-3.10.0.tar.gz \
     && cd cmake-3.10.0 \
     && ./bootstrap \
-    && make -j 4 \
+    && make \
     && make install
 
 ###############################################################################
@@ -48,7 +49,7 @@ RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
     && ./config \
     && make \
-    && sudo make install
+    && make install
 
 ###############################################################################
 # Clone and build Google Test
@@ -64,9 +65,20 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
     && cp -a lib/* /usr/lib64/ \
     && rm -f /tmp/release-1.10.0.tar.gz
 
-# ###############################################################################
-# # Install Aws Iot Device Sdk Cpp v2
-# ###############################################################################
+###############################################################################
+# Clone and build valgrind
+###############################################################################
+WORKDIR /tmp
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 \
+    && tar jxvf valgrind-3.19.0.tar.bz2 \
+    && cd valgrind-3.19.0 \
+    && ./configure \
+    && make \
+    && make install
+
+################################################################################
+# Install Aws Iot Device Sdk Cpp v2
+################################################################################
 WORKDIR /home/aws-iot-device-client
 RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq \
     build-essential \
     wget \
     cppcheck \
-    valgrind \
+    libc6-dbg \
     && apt-get clean
 
 ###############################################################################
@@ -52,6 +52,17 @@ RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
     && cp -a googletest/include/gtest /usr/include/ \
     && cp -a googlemock/include/gmock /usr/include/ \
     && cp -a lib/* /usr/lib/
+
+###############################################################################
+# Clone and build valgrind
+###############################################################################
+WORKDIR /tmp
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 \
+    && tar jxvf valgrind-3.19.0.tar.bz2 \
+    && cd valgrind-3.19.0 \
+    && ./configure \
+    && make \
+    && make install
 
 ###############################################################################
 # Install Aws Iot Device Sdk Cpp v2

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
     build-essential \
     wget \
     cppcheck \
+    valgrind \
     && apt-get clean
 
 ###############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -113,7 +113,9 @@ set_tests_properties(${GTEST_PROJECT} PROPERTIES ENVIRONMENT AWS_CRT_MEMORY_TRAC
 
 # Add custom target for detecting memory leaks while running unit tests.
 find_program(VALGRIND_PATH valgrind)
-add_custom_target(
-    ${GTEST_PROJECT}-leak-check
-    COMMAND ${VALGRIND_PATH} --leak-check=yes --error-exitcode=1 ./${GTEST_PROJECT}
-    DEPENDS ${GTEST_PROJECT})
+if (VALGRIND_PATH)
+    add_custom_target(
+        ${GTEST_PROJECT}-leak-check
+        COMMAND ${VALGRIND_PATH} --leak-check=yes --error-exitcode=1 ./${GTEST_PROJECT}
+        DEPENDS ${GTEST_PROJECT})
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,3 +110,10 @@ endif ()
 
 add_test(${GTEST_PROJECT} ${GTEST_PROJECT})
 set_tests_properties(${GTEST_PROJECT} PROPERTIES ENVIRONMENT AWS_CRT_MEMORY_TRACING=1)
+
+# Add custom target for detecting memory leaks while running unit tests.
+find_program(VALGRIND_PATH valgrind)
+add_custom_target(
+    ${GTEST_PROJECT}-leak-check
+    COMMAND ${VALGRIND_PATH} --leak-check=yes --error-exitcode=1 ./${GTEST_PROJECT}
+    DEPENDS ${GTEST_PROJECT})

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -576,7 +576,7 @@ TEST_F(ConfigTestFixture, PubSubSampleConfig)
     string samplesFilePath = "/tmp/" + UniqueString::GetRandomToken(10);
     FileUtils::StoreValueInFile("Test", samplesFilePath);
     chmod(samplesFilePath.c_str(), 0600);
-    auto jsonTemplate = R"(
+    std::string jsonTemplate = R"(
 {
 	"endpoint": "endpoint value",
 	"cert": "/tmp/aws-iot-device-client-test-file",


### PR DESCRIPTION
### Motivation
* Add memory leak detection when running unit tests using valgrind.

### Modifications
* Add valgrind to the base image.
* Run valgrind when running unit tests from build.sh.
* Add custom target named `test-aws-iot-device-client-leak-check` to cmake that runs the unit tests with valgrind in the same way as build.sh.

### Testing
* Unit tests only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
