### PR TITLE
bump ubuntu version, fix build issues with gcc 11

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -84,7 +84,7 @@ else
           echo "ver"
           echo $ver
           apt-get --assume-yes install apt-transport-https
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add
+          wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add
           apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$ver main" -y
           apt-get update
           apt-get --assume-yes install clang-$ver

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -112,7 +112,7 @@ case $compileMode in
     apt-get install --assume-yes g++-arm-linux-gnueabihf
     apt-get install --assume-yes gcc-arm-linux-gnueabihf
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
     tar -xvzf openssl-${OPENSSL_VERSION}.tar.gz
     export INSTALL_DIR=/usr/lib/arm-linux-gnueabihf
     cd openssl-${OPENSSL_VERSION}
@@ -150,7 +150,7 @@ case $compileMode in
     apt-get install --assume-yes g++-mips-linux-gnu
     apt-get install --assume-yes gcc-mips-linux-gnu
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
     tar -xvzf openssl-${OPENSSL_VERSION}.tar.gz
     export INSTALL_DIR=/usr/lib/mips-linux-gnu
     cd openssl-${OPENSSL_VERSION}
@@ -183,7 +183,7 @@ case $compileMode in
     apt-get install --assume-yes g++-aarch64-linux-gnu
     apt-get install --assume-yes gcc-aarch64-linux-gnu
     apt-get install --assume-yes gdb-multiarch
-    wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
     tar -xvzf openssl-${OPENSSL_VERSION}.tar.gz
     export INSTALL_DIR=/usr/lib/aarch64-linux-gnu
     cd openssl-${OPENSSL_VERSION}

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,13 +8,10 @@ ARG OPENSSL_VERSION=1.1.1n
 # Install prereqs
 ###############################################################################
 RUN apt-get update -qq \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt-get -y install \
     git \
     curl \
     build-essential \
-    gcc-11 \
-    g++-11 \
     wget \
     cppcheck \
     libc6-dbg \
@@ -47,7 +44,7 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
+RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz --no-check-certificate \
     && tar xf release-1.10.0.tar.gz \
     && cd googletest-release-1.10.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
@@ -60,7 +57,7 @@ RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
 # Clone and build valgrind
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 \
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 --no-check-certificate \
     && tar jxvf valgrind-3.19.0.tar.bz2 \
     && cd valgrind-3.19.0 \
     && ./configure \

--- a/.github/docker-images/ubuntu-16-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-16-x64/Dockerfile
@@ -8,10 +8,13 @@ ARG OPENSSL_VERSION=1.1.1n
 # Install prereqs
 ###############################################################################
 RUN apt-get update -qq \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt-get -y install \
     git \
     curl \
     build-essential \
+    gcc-11 \
+    g++-11 \
     wget \
     cppcheck \
     libc6-dbg \

--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz --no-check-certificate \
+RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
     && tar xf release-1.10.0.tar.gz \
     && cd googletest-release-1.10.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
@@ -57,7 +57,7 @@ RUN wget https://github.com/google/googletest/archive/release-1.10.0.tar.gz --no
 # Clone and build valgrind
 ###############################################################################
 WORKDIR /tmp
-RUN wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 --no-check-certificate \
+RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2 \
     && tar jxvf valgrind-3.19.0.tar.bz2 \
     && cd valgrind-3.19.0 \
     && ./configure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/18-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compiler=g++-${{ matrix.version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     strategy:
       matrix:
-        version: [ 5,6,7,8,11 ]
+        version: [ 5, 6, 7, 8, 11 ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -136,7 +136,7 @@ jobs:
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     strategy:
       matrix:
-        version: [ 5.0, 6.0, 7, 8, 9 ]
+        version: [ 5.0, 6.0, 7, 8, 9, 11 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     strategy:
       matrix:
-        version: [ 5,6,7,8 ]
+        version: [ 5,6,7,8,11 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         branch: gh-pages
         force: true
 
-  build-ubuntu-16-x64:
+  build-ubuntu-18-x64:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
@@ -53,7 +53,7 @@ jobs:
           export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE
-      - name: Archive ubuntu-16-x64 Build Artifact
+      - name: Archive ubuntu-18-x64 Build Artifact
         uses: actions/upload-artifact@v2
         # Run for main branch only
         if: github.ref == 'refs/heads/main'
@@ -127,7 +127,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compiler=g++-${{ matrix.version }}
 
@@ -144,7 +144,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compiler=clang-${{ matrix.version }}
 
@@ -158,7 +158,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=armhf_cross_mode
       - name: Archive armhf32 Build Artifact
@@ -188,7 +188,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=mips_cross_mode
       - name: Archive mips32 Build Artifact
@@ -218,7 +218,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=aarch64_cross_mode
       - name: Archive aarch64 Build Artifact
@@ -238,7 +238,7 @@ jobs:
           path: |
             ./setup/
 
-  build-shared-libs-ubuntu-16-x64:
+  build-shared-libs-ubuntu-18-x64:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
@@ -248,10 +248,10 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=shared_lib_mode
-      - name: Archive ubuntu-16-x64 Build Artifact
+      - name: Archive ubuntu-18-x64 Build Artifact
         uses: actions/upload-artifact@v2
         # Run for main branch only
         if: github.ref == 'refs/heads/main'
@@ -338,7 +338,7 @@ jobs:
         - name: Build ${{ env.PACKAGE_NAME }}
           run: |
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-            export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+            export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
             docker pull $DOCKER_IMAGE
             docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=armhf_cross_mode_shared_libs
         - name: Archive armhf32 Build Artifact
@@ -376,7 +376,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=mips_cross_mode_shared_libs
       - name: Archive mips32 Build Artifact
@@ -414,7 +414,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=aarch64_cross_mode_shared_libs
       - name: Archive aarch64 Build Artifact
@@ -442,7 +442,7 @@ jobs:
           path: |
             ./setup/
 
-  build-st-ubuntu-16-x64:
+  build-st-ubuntu-18-x64:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
@@ -452,7 +452,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} ST Component Mode
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_component_mode
       - name: Archive ST Component Mode Build Artifact
@@ -464,7 +464,7 @@ jobs:
           path: |
             ./build/${{ env.PACKAGE_NAME }}
 
-  build-st-ubuntu-16-aarch64:
+  build-st-ubuntu-18-aarch64:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
@@ -474,7 +474,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_aarch64_cross_mode
       - name: Archive ST Ubuntu aarch64 Build Artifact
@@ -486,7 +486,7 @@ jobs:
           path: |
             ./build/${{ env.PACKAGE_NAME }}
 
-  build-st-ubuntu-16-armhf32:
+  build-st-ubuntu-18-armhf32:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
@@ -496,7 +496,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE --compile-mode=st_armhf_cross_mode
       - name: Archive st armhf32 Build Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-16-x64:latest
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
           docker pull $DOCKER_IMAGE
           docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE
       - name: Archive ubuntu-16-x64 Build Artifact

--- a/source/shadow/SampleShadowFeature.cpp
+++ b/source/shadow/SampleShadowFeature.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <sys/stat.h>
+#include <thread>
 #include <unistd.h>
 #include <utility>
 

--- a/source/util/Retry.cpp
+++ b/source/util/Retry.cpp
@@ -3,6 +3,7 @@
 
 #include "Retry.h"
 #include "../logging/LoggerFactory.h"
+#include <thread>
 
 using namespace std;
 using namespace Aws::Iot::DeviceClient::Logging;

--- a/test/jobs/TestEphemeralPromise.cpp
+++ b/test/jobs/TestEphemeralPromise.cpp
@@ -3,6 +3,7 @@
 
 #include "../../source/jobs/EphemeralPromise.h"
 #include "gtest/gtest.h"
+#include <thread>
 
 using namespace std;
 using namespace Aws::Iot::DeviceClient::Jobs;


### PR DESCRIPTION
### Motivation
- Build with gcc 11 fails when calling this_thread::sleep_for.
- Found when investigating the issue below.
- Issue number: #146 


### Modifications
#### Change summary
Added missing headers to fix.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
