### PR TITLE
Root ca fix

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -113,7 +113,16 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
     {
         if (!json.GetString(jsonKey).empty())
         {
-            rootCa = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+            basic_string<char> path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+            if (!FileUtils::FileExists(path))
+            {
+                LOGM_ERROR(Config::TAG, "Path %s to RootCA is invalid. Ignoring... Will attempt to use default trust store.", path.c_str());
+                rootCa = "";
+            }
+            else
+            {
+                rootCa = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+            }
         }
         else
         {

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -116,7 +116,10 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
             basic_string<char> path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             if (!FileUtils::FileExists(path))
             {
-                LOGM_ERROR(Config::TAG, "Path %s to RootCA is invalid. Ignoring... Will attempt to use default trust store.", path.c_str());
+                LOGM_ERROR(
+                    Config::TAG,
+                    "Path %s to RootCA is invalid. Ignoring... Will attempt to use default trust store.",
+                    path.c_str());
                 rootCa = "";
             }
             else

--- a/source/util/FileUtils.cpp
+++ b/source/util/FileUtils.cpp
@@ -362,7 +362,6 @@ bool FileUtils::IsValidFilePath(const string &filePath)
         case WRDE_NOSPACE:
             wordfree(&word);
         default:
-            LOGM_ERROR(TAG, "%s is an invalid file path", Sanitize(filePath).c_str());
             return false;
     }
 
@@ -370,7 +369,6 @@ bool FileUtils::IsValidFilePath(const string &filePath)
 
     if (!FileUtils::FileExists(expandedPath))
     {
-        LOGM_ERROR(TAG, "%s is an invalid file path", Sanitize(filePath).c_str());
         wordfree(&word);
         return false;
     }

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -21,6 +21,7 @@ using namespace Aws::Iot::DeviceClient;
 using namespace Aws::Iot::DeviceClient::Util;
 
 const string filePath = "/tmp/aws-iot-device-client-test-file";
+const string invalidFilePath = "/tmp/invalid-file-path";
 
 class ConfigTestFixture : public ::testing::Test
 {
@@ -48,7 +49,6 @@ static CliArgs makeMinimumCliArgs()
         {PlainConfig::CLI_ENDPOINT, "endpoint value"},
         {PlainConfig::CLI_CERT, filePath},
         {PlainConfig::CLI_KEY, filePath},
-        {PlainConfig::CLI_ROOT_CA, filePath},
         {PlainConfig::CLI_THING_NAME, "thing-name value"},
     };
 }
@@ -167,7 +167,6 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumConfig)
     "endpoint": "endpoint value",
     "cert": "/tmp/aws-iot-device-client-test-file",
     "key": "/tmp/aws-iot-device-client-test-file",
-    "root-ca": "/tmp/aws-iot-device-client-test-file",
     "thing-name": "thing-name value"
 })";
     JsonObject jsonObject(jsonString);
@@ -180,7 +179,6 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumConfig)
     ASSERT_STREQ("endpoint value", config.endpoint->c_str());
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
-    ASSERT_STREQ(filePath.c_str(), config.rootCa->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_TRUE(config.jobs.enabled);
     ASSERT_TRUE(config.tunneling.enabled);
@@ -199,7 +197,58 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumCli)
     ASSERT_STREQ("endpoint value", config.endpoint->c_str());
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
-    ASSERT_STREQ(filePath.c_str(), config.rootCa->c_str());
+    ASSERT_STREQ("thing-name value", config.thingName->c_str());
+    ASSERT_TRUE(config.jobs.enabled);
+    ASSERT_TRUE(config.tunneling.enabled);
+    ASSERT_TRUE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.fleetProvisioning.enabled);
+}
+
+TEST_F(ConfigTestFixture, InvalidRootCaPathConfig)
+{
+    constexpr char jsonString[] = R"(
+{
+    "endpoint": "endpoint value",
+    "cert": "/tmp/aws-iot-device-client-test-file",
+    "key": "/tmp/aws-iot-device-client-test-file",
+    "root-ca": "/tmp/invalid-file-path",
+    "thing-name": "thing-name value"
+})";
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    ASSERT_TRUE(config.Validate());
+    ASSERT_STREQ("endpoint value", config.endpoint->c_str());
+    ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
+    ASSERT_STREQ(filePath.c_str(), config.key->c_str());
+    ASSERT_FALSE(config.rootCa.has_value());
+    ASSERT_STREQ("thing-name value", config.thingName->c_str());
+    ASSERT_TRUE(config.jobs.enabled);
+    ASSERT_TRUE(config.tunneling.enabled);
+    ASSERT_TRUE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.fleetProvisioning.enabled);
+}
+
+TEST_F(ConfigTestFixture, InvalidRootCaPathConfigCli)
+{
+    CliArgs cliArgs;
+    cliArgs[PlainConfig::CLI_ENDPOINT] = "endpoint value";
+    cliArgs[PlainConfig::CLI_CERT] = filePath;
+    cliArgs[PlainConfig::CLI_KEY] = filePath;
+    cliArgs[PlainConfig::CLI_THING_NAME] = "thing-name value";
+    cliArgs[PlainConfig::CLI_ROOT_CA] = invalidFilePath;
+
+    PlainConfig config;
+    config.LoadFromCliArgs(cliArgs);
+
+    ASSERT_TRUE(config.Validate());
+    ASSERT_STREQ("endpoint value", config.endpoint->c_str());
+    ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
+    ASSERT_STREQ(filePath.c_str(), config.key->c_str());
+    ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_TRUE(config.jobs.enabled);
     ASSERT_TRUE(config.tunneling.enabled);

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -34,6 +34,9 @@ class ConfigTestFixture : public ::testing::Test
         // Create a temporary file to use as a placeholder for this purpose.
         ofstream file(filePath, std::fstream::app);
         file << "test message" << endl;
+
+        // Ensure invalid-file does not exist
+        std::remove(invalidFilePath.c_str());
     }
 
     void TearDown() override { std::remove(filePath.c_str()); }


### PR DESCRIPTION
### Motivation
The GG ST Component passes a placeholder value for root-ca which was causing failures.

### Modifications
#### Change summary
Use an empty string when root-ca path is invalid.

### Testing
Manually tested by opening tunnels.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
