### PR TITLE
Root ca fix

### DIFF
--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -75,23 +75,6 @@ bool SharedCrtResourceManager::locateCredentials(const PlainConfig &config)
         }
     }
 
-    if (stat(config.rootCa->c_str(), &fileInfo) != 0)
-    {
-        LOGM_ERROR(
-            TAG, "Failed to find %s, cannot establish MQTT connection", Sanitize(config.rootCa->c_str()).c_str());
-        locatedAll = false;
-    }
-    else
-    {
-        string parentDir = FileUtils::ExtractParentDirectory(config.rootCa->c_str());
-        if (!FileUtils::ValidateFilePermissions(parentDir, Permissions::ROOT_CA_DIR) ||
-            !FileUtils::ValidateFilePermissions(config.rootCa->c_str(), Permissions::ROOT_CA))
-        {
-            LOG_ERROR(TAG, "Incorrect permissions on Root CA file and/or parent directory");
-            locatedAll = false;
-        }
-    }
-
     return locatedAll;
 }
 
@@ -252,7 +235,9 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     }
     auto clientConfigBuilder = MqttClientConnectionConfigBuilder(config.cert->c_str(), config.key->c_str());
     clientConfigBuilder.WithEndpoint(config.endpoint->c_str());
-    clientConfigBuilder.WithCertificateAuthority(config.rootCa->c_str());
+    if(config.rootCa.has_value()) {
+        clientConfigBuilder.WithCertificateAuthority(config.rootCa->c_str());
+    }
     clientConfigBuilder.WithSdkName(SharedCrtResourceManager::BINARY_NAME);
     clientConfigBuilder.WithSdkVersion(DEVICE_CLIENT_VERSION);
 

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -235,7 +235,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     }
     auto clientConfigBuilder = MqttClientConnectionConfigBuilder(config.cert->c_str(), config.key->c_str());
     clientConfigBuilder.WithEndpoint(config.endpoint->c_str());
-    if(config.rootCa.has_value()) {
+    if (config.rootCa.has_value())
+    {
         clientConfigBuilder.WithCertificateAuthority(config.rootCa->c_str());
     }
     clientConfigBuilder.WithSdkName(SharedCrtResourceManager::BINARY_NAME);

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -235,7 +235,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     }
     auto clientConfigBuilder = MqttClientConnectionConfigBuilder(config.cert->c_str(), config.key->c_str());
     clientConfigBuilder.WithEndpoint(config.endpoint->c_str());
-    if (config.rootCa.has_value())
+    if (config.rootCa.has_value() && !config.rootCa->empty())
     {
         clientConfigBuilder.WithCertificateAuthority(config.rootCa->c_str());
     }

--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -50,6 +50,12 @@ namespace Aws
 
                 void initializeAllocator(const PlainConfig &config);
 
+              protected:
+                /**
+                 * inheritable for testing
+                 */
+                bool locateCredentials(const PlainConfig &config);
+
               public:
                 SharedCrtResourceManager() = default;
 
@@ -66,8 +72,6 @@ namespace Aws
                 static const int SUCCESS = 0;
                 static const int RETRY = 1;
                 static const int ABORT = 2;
-
-                bool locateCredentials(const PlainConfig &config);
 
                 bool initialize(const PlainConfig &config, std::vector<Feature *> *features);
 

--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -44,8 +44,6 @@ namespace Aws
                 aws_mem_trace_level memTraceLevel{AWS_MEMTRACE_NONE};
                 std::vector<Feature *> *features;
 
-                bool locateCredentials(const PlainConfig &config);
-
                 bool setupLogging(const PlainConfig &config);
 
                 int buildClient(const PlainConfig &config);
@@ -68,6 +66,8 @@ namespace Aws
                 static const int SUCCESS = 0;
                 static const int RETRY = 1;
                 static const int ABORT = 2;
+
+                bool locateCredentials(const PlainConfig &config);
 
                 bool initialize(const PlainConfig &config, std::vector<Feature *> *features);
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -121,11 +121,7 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
             auto path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             if (FileUtils::FileExists(path))
             {
-                FileUtils::ValidateFilePermissions(
-                    FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
-                FileUtils::ValidateFilePermissions(path, Permissions::ROOT_CA, false);
-
-                rootCa = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
+                rootCa = path;
             }
             else
             {
@@ -355,7 +351,7 @@ bool PlainConfig::Validate() const
         LOGM_ERROR(Config::TAG, "*** %s: Thing name is missing ***", DeviceClient::DC_FATAL_ERROR);
         return false;
     }
-    if (rootCa.has_value() && FileUtils::FileExists(rootCa->c_str()))
+    if (rootCa.has_value() && !rootCa->empty() && FileUtils::FileExists(rootCa->c_str()))
     {
         string parentDir = FileUtils::ExtractParentDirectory(rootCa->c_str());
         if (!FileUtils::ValidateFilePermissions(parentDir, Permissions::ROOT_CA_DIR) ||

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -322,6 +322,16 @@ bool PlainConfig::Validate() const
             Sanitize(lockFilePath).c_str());
         return false;
     }
+    if (rootCa.has_value() && !rootCa->empty() && FileUtils::FileExists(rootCa->c_str()))
+    {
+        string parentDir = FileUtils::ExtractParentDirectory(rootCa->c_str());
+        if (!FileUtils::ValidateFilePermissions(parentDir, Permissions::ROOT_CA_DIR) ||
+            !FileUtils::ValidateFilePermissions(rootCa->c_str(), Permissions::ROOT_CA))
+        {
+            LOG_ERROR(Config::TAG, "Incorrect permissions on Root CA file and/or parent directory");
+            return false;
+        }
+    }
 #if !defined(DISABLE_MQTT)
     if (!endpoint.has_value() || endpoint->empty())
     {
@@ -350,16 +360,6 @@ bool PlainConfig::Validate() const
     {
         LOGM_ERROR(Config::TAG, "*** %s: Thing name is missing ***", DeviceClient::DC_FATAL_ERROR);
         return false;
-    }
-    if (rootCa.has_value() && !rootCa->empty() && FileUtils::FileExists(rootCa->c_str()))
-    {
-        string parentDir = FileUtils::ExtractParentDirectory(rootCa->c_str());
-        if (!FileUtils::ValidateFilePermissions(parentDir, Permissions::ROOT_CA_DIR) ||
-            !FileUtils::ValidateFilePermissions(rootCa->c_str(), Permissions::ROOT_CA))
-        {
-            LOG_ERROR(Config::TAG, "Incorrect permissions on Root CA file and/or parent directory");
-            return false;
-        }
     }
 #endif
 #if !defined(EXCLUDE_JOBS)

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -121,6 +121,9 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
             auto path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             if (FileUtils::FileExists(path))
             {
+                FileUtils::ValidateFilePermissions(FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
+                FileUtils::ValidateFilePermissions(path, Permissions::ROOT_CA, false);
+
                 rootCa = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             }
             else
@@ -249,6 +252,10 @@ bool PlainConfig::LoadFromCliArgs(const CliArgs &cliArgs)
         auto path = FileUtils::ExtractExpandedPath(cliArgs.at(PlainConfig::CLI_ROOT_CA).c_str());
         if (FileUtils::IsValidFilePath(path))
         {
+            // Log warnings if root-ca permissions are incorrect
+            FileUtils::ValidateFilePermissions(FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
+            FileUtils::ValidateFilePermissions(path, Permissions::ROOT_CA, false);
+
             rootCa = FileUtils::ExtractExpandedPath(cliArgs.at(PlainConfig::CLI_ROOT_CA).c_str());
         }
         else

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -254,7 +254,8 @@ bool PlainConfig::LoadFromCliArgs(const CliArgs &cliArgs)
         if (FileUtils::IsValidFilePath(path))
         {
             // Log warnings if root-ca permissions are incorrect
-            FileUtils::ValidateFilePermissions(FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
+            FileUtils::ValidateFilePermissions(
+                FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
             FileUtils::ValidateFilePermissions(path, Permissions::ROOT_CA, false);
 
             rootCa = FileUtils::ExtractExpandedPath(cliArgs.at(PlainConfig::CLI_ROOT_CA).c_str());

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -121,7 +121,8 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
             auto path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             if (FileUtils::FileExists(path))
             {
-                FileUtils::ValidateFilePermissions(FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
+                FileUtils::ValidateFilePermissions(
+                    FileUtils::ExtractParentDirectory(path), Permissions::ROOT_CA_DIR, false);
                 FileUtils::ValidateFilePermissions(path, Permissions::ROOT_CA, false);
 
                 rootCa = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -293,7 +293,7 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaCli)
     DefaultFeaturesEnabled(config);
 }
 
-#if !defined(MQTT_DISABLED)
+#if defined(MQTT_DISABLED)
 /**
  * Explicitly pass root-ca path via JSON with invalid permissions on parent directory
  * Expect validation to fail
@@ -315,7 +315,6 @@ TEST_F(ConfigTestFixture, ExplicitRootCaBadParentPermissionsConfig)
     config.LoadFromJson(jsonView);
 
     chmod(nonStandardDir.c_str(), 0777);
-
     ASSERT_FALSE(config.Validate());
 }
 
@@ -387,6 +386,7 @@ TEST_F(ConfigTestFixture, ExplicitRootCaBadPermissionsCli)
 
     ASSERT_FALSE(config.Validate());
 }
+
 #endif
 
 /**

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -293,6 +293,7 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaCli)
     DefaultFeaturesEnabled(config);
 }
 
+#if !defined(MQTT_DISABLED)
 /**
  * Explicitly pass root-ca path via JSON with invalid permissions on parent directory
  * Expect validation to fail
@@ -386,6 +387,7 @@ TEST_F(ConfigTestFixture, ExplicitRootCaBadPermissionsCli)
 
     ASSERT_FALSE(config.Validate());
 }
+#endif
 
 /**
  * Explicitly pass root-ca path to non-existent file via JSON

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -293,7 +293,6 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaCli)
     DefaultFeaturesEnabled(config);
 }
 
-#if defined(MQTT_DISABLED)
 /**
  * Explicitly pass root-ca path via JSON with invalid permissions on parent directory
  * Expect validation to fail
@@ -386,8 +385,6 @@ TEST_F(ConfigTestFixture, ExplicitRootCaBadPermissionsCli)
 
     ASSERT_FALSE(config.Validate());
 }
-
-#endif
 
 /**
  * Explicitly pass root-ca path to non-existent file via JSON

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1191,6 +1191,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
 {
     "endpoint": "endpoint value",
     "cert": "/tmp/aws-iot-device-client-test-file",
+    "root-ca": "/tmp/aws-iot-device-client-test/AmazonRootCA1.pem",
     "key": "/tmp/aws-iot-device-client-test-file",
     "thing-name": "thing-name value",
     "sensor-publish": {

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -44,6 +44,12 @@ static PlainConfig getConfig(string certPath, string keyPath)
     return config;
 }
 
+class SharedCrtResourceManagerWrapper : public SharedCrtResourceManager
+{
+  public:
+    bool locateCredentialsWrapper(const PlainConfig &config) { return locateCredentials(config); }
+};
+
 class SharedResourceManagerTest : public ::testing::Test
 {
   public:
@@ -87,65 +93,61 @@ class SharedResourceManagerTest : public ::testing::Test
         std::remove(badPermissionsCertFilePath.c_str());
         std::remove(badPermissionsKeyFilePath.c_str());
     }
+
+    SharedCrtResourceManagerWrapper manager;
 };
 
 TEST_F(SharedResourceManagerTest, locateCredentialsHappy)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(certFilePath, keyFilePath);
 
-    ASSERT_TRUE(manager.locateCredentials(config));
+    ASSERT_TRUE(manager.locateCredentialsWrapper(config));
 }
 
 TEST_F(SharedResourceManagerTest, badPermissionsCert)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(badPermissionsCertFilePath, keyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentials(config));
+    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
 TEST_F(SharedResourceManagerTest, badPermissionsKey)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(certFilePath, badPermissionsKeyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentials(config));
+    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
 TEST_F(SharedResourceManagerTest, invalidCert)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(invalidCertFilePath, keyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentials(config));
+    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
 TEST_F(SharedResourceManagerTest, invalidKey)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(invalidCertFilePath, keyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentials(config));
+    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
 TEST_F(SharedResourceManagerTest, badPermissionsDirectory)
 {
-    SharedCrtResourceManager manager;
 
     PlainConfig config;
     config = getConfig(certFilePath, keyFilePath);
     chmod(certDir.c_str(), 0777);
 
-    ASSERT_FALSE(manager.locateCredentials(config));
+    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -35,8 +35,6 @@ static PlainConfig getConfig(string certPath, string keyPath)
                              "\"cert\": \"" +
                              certPath + "\",\n\"key\": \"" + keyPath + "\"}";
 
-    cout << jsonString << endl;
-
     JsonObject jsonObject(jsonString.c_str());
     JsonView jsonView = jsonObject.View();
 

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../source/SharedCrtResourceManager.h"
+#include "../../source/util/FileUtils.h"
+#include "gtest/gtest.h"
+
+#include <string>
+#include <sys/stat.h>
+
+using namespace std;
+using namespace Aws;
+using namespace Aws::Crt;
+using namespace Aws::Iot;
+using namespace Aws::Iot::DeviceClient;
+using namespace Aws::Iot::DeviceClient::Util;
+
+const string certDir = "/tmp/device-client-test";
+const string certFilePath = "/tmp/device-client-test/aws-iot-device-client-test-cert";
+const string keyFilePath = "/tmp/device-client-test/aws-iot-device-client-test-key";
+
+const string invalidSuffix = "-invalid";
+const string badPermissionsSuffix = "-bad-permissions";
+
+const string badPermissionsCertFilePath = certFilePath + badPermissionsSuffix;
+const string badPermissionsKeyFilePath = keyFilePath + badPermissionsSuffix;
+
+const string invalidCertFilePath = certFilePath + invalidSuffix;
+const string invalidKeyFilePath = keyFilePath + invalidSuffix;
+
+static PlainConfig getConfig(string certPath, string keyPath)
+{
+
+    std::string jsonString = "{\"endpoint\": \"endpoint value\",\n"
+                             "\"cert\": \"" +
+                             certPath + "\",\n\"key\": \"" + keyPath + "\"}";
+
+    cout << jsonString << endl;
+
+    JsonObject jsonObject(jsonString.c_str());
+    JsonView jsonView = jsonObject.View();
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    return config;
+}
+
+class SharedResourceManagerTest : public ::testing::Test
+{
+  public:
+    SharedResourceManagerTest() = default;
+
+    void SetUp() override
+    {
+        // SharedCrtResourceManager::locateCredentials will check that cert, key files
+        // have valid permissions. Create a temporary file to use as a placeholder for this purpose.
+        FileUtils::CreateDirectoryWithPermissions(certDir.c_str(), 0700);
+        ofstream certFile(certFilePath, std::fstream::app);
+        certFile << "test cert" << endl;
+
+        ofstream keyFile(keyFilePath, std::fstream::app);
+        keyFile << "test key" << endl;
+
+        chmod(certFilePath.c_str(), 0644);
+        chmod(keyFilePath.c_str(), 0600);
+
+        // Create files with incorrect permissions
+        ofstream badPermsCertFile(badPermissionsCertFilePath, std::fstream::app);
+        badPermsCertFile << "test cert" << endl;
+
+        ofstream badPermsKeyFile(badPermissionsKeyFilePath, std::fstream::app);
+        badPermsKeyFile << "test key" << endl;
+
+        chmod(badPermissionsCertFilePath.c_str(), 0777);
+        chmod(badPermissionsKeyFilePath.c_str(), 0777);
+
+        // Ensure invalid files do not exist
+        std::remove(invalidCertFilePath.c_str());
+        std::remove(invalidKeyFilePath.c_str());
+    }
+
+    void TearDown() override
+    {
+        std::remove(certFilePath.c_str());
+        std::remove(keyFilePath.c_str());
+        std::remove(certDir.c_str());
+
+        std::remove(badPermissionsCertFilePath.c_str());
+        std::remove(badPermissionsKeyFilePath.c_str());
+    }
+};
+
+TEST_F(SharedResourceManagerTest, locateCredentialsHappy)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(certFilePath, keyFilePath);
+
+    ASSERT_TRUE(manager.locateCredentials(config));
+}
+
+TEST_F(SharedResourceManagerTest, badPermissionsCert)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(badPermissionsCertFilePath, keyFilePath);
+
+    ASSERT_FALSE(manager.locateCredentials(config));
+}
+
+TEST_F(SharedResourceManagerTest, badPermissionsKey)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(certFilePath, badPermissionsKeyFilePath);
+
+    ASSERT_FALSE(manager.locateCredentials(config));
+}
+
+TEST_F(SharedResourceManagerTest, invalidCert)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(invalidCertFilePath, keyFilePath);
+
+    ASSERT_FALSE(manager.locateCredentials(config));
+}
+
+TEST_F(SharedResourceManagerTest, invalidKey)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(invalidCertFilePath, keyFilePath);
+
+    ASSERT_FALSE(manager.locateCredentials(config));
+}
+
+TEST_F(SharedResourceManagerTest, badPermissionsDirectory)
+{
+    SharedCrtResourceManager manager;
+
+    PlainConfig config;
+    config = getConfig(certFilePath, keyFilePath);
+    chmod(certDir.c_str(), 0777);
+
+    ASSERT_FALSE(manager.locateCredentials(config));
+}


### PR DESCRIPTION
### Motivation
Empty or invalid root-ca path would cause segmentation fault in the resource manager.


### Modifications
#### Change summary
This change will ignore empty or invalid root-ca paths. mqtt client will default to default trust store if no root-ca is passed.

### Testing
Manually tested with empty root-ca, invalid root-ca, then a valid root-ca path to an invalid root-ca.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
