### PR TITLE
Fixes formatting and lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,24 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v1
+      - name: Checkout Sources
+        uses: actions/checkout@v1
 
-    - name: clang-format lint
-      uses: DoozyX/clang-format-lint-action@v0.3.1
-      with:
-        # List of extensions to check
-        extensions: cpp,h
+      - name: clang-format lint
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/amazonlinux:latest
+          docker pull $DOCKER_IMAGE
+          docker run --mount type=bind,source=$(pwd),target=/src --workdir /src --entrypoint /src/format-check.sh $DOCKER_IMAGE
+
 
   cppcheck:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v1
-    - name: cppcheck script
-      run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
-        export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/amazonlinux:latest
-        docker pull $DOCKER_IMAGE
-        docker run --mount type=bind,source=$(pwd),target=/src --workdir /src --entrypoint /src/run-cppcheck.sh $DOCKER_IMAGE
+      - name: Checkout Sources
+        uses: actions/checkout@v1
+      - name: cppcheck script
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+          export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/amazonlinux:latest
+          docker pull $DOCKER_IMAGE
+          docker run --mount type=bind,source=$(pwd),target=/src --workdir /src --entrypoint /src/run-cppcheck.sh $DOCKER_IMAGE

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -266,7 +266,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
+    {
         if (errorCode)
         {
             LOGM_ERROR(TAG, "MQTT Connection failed with error: %s", ErrorDebugString(errorCode));
@@ -290,7 +291,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
+    {
         {
             LOG_INFO(TAG, "MQTT Connection is now disconnected");
             connectionClosedPromise.set_value();
@@ -300,7 +302,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     /*
      * Invoked when connection is interrupted.
      */
-    auto OnConnectionInterrupted = [&](Mqtt::MqttConnection &, int errorCode) {
+    auto OnConnectionInterrupted = [&](Mqtt::MqttConnection &, int errorCode)
+    {
         {
             if (errorCode)
             {
@@ -316,7 +319,8 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     /*
      * Invoked when connection is resumed.
      */
-    auto OnConnectionResumed = [&](Mqtt::MqttConnection &, int returnCode, bool) {
+    auto OnConnectionResumed = [&](Mqtt::MqttConnection &, int returnCode, bool)
+    {
         {
             LOGM_INFO(TAG, "MQTT connection resumed with return code: %d", returnCode);
         }

--- a/source/devicedefender/DeviceDefenderFeature.cpp
+++ b/source/devicedefender/DeviceDefenderFeature.cpp
@@ -39,7 +39,8 @@ void DeviceDefenderFeature::startDeviceDefender()
 {
     LOGM_INFO(TAG, "Starting %s", getName().c_str());
 
-    auto onCancelled = [&](void *userData) -> void {
+    auto onCancelled = [&](void *userData) -> void
+    {
         LOGM_DEBUG(TAG, "task called onCancelled for thing: %s", thingName.c_str());
         stop();
     };
@@ -59,13 +60,11 @@ void DeviceDefenderFeature::startDeviceDefender()
     task->StartTask();
     LOGM_DEBUG(TAG, "%s StartTask() async called", getName().c_str());
 
-    auto onRecvData = [&](MqttConnection &connection, const String &topic, const ByteBuf &payload) -> void {
-        LOGM_DEBUG(TAG, "Recv: Topic:(%s), Payload:%s", topic.c_str(), (char *)payload.buffer);
-    };
+    auto onRecvData = [&](MqttConnection &connection, const String &topic, const ByteBuf &payload) -> void
+    { LOGM_DEBUG(TAG, "Recv: Topic:(%s), Payload:%s", topic.c_str(), (char *)payload.buffer); };
     auto onSubAck =
-        [&](MqttConnection &connection, uint16_t packetId, const String &topic, QOS qos, int errorCode) -> void {
-        LOGM_DEBUG(TAG, "SubAck: PacketId:(%s), ErrorCode:%i", getName().c_str(), errorCode);
-    };
+        [&](MqttConnection &connection, uint16_t packetId, const String &topic, QOS qos, int errorCode) -> void
+    { LOGM_DEBUG(TAG, "SubAck: PacketId:(%s), ErrorCode:%i", getName().c_str(), errorCode); };
     const char *messageFormat = "%s%s%s%s";
     resourceManager->getConnection()->Subscribe(
         FormatMessage(messageFormat, TOPIC_PRE, thingName.c_str(), TOPIC_POST, TOPIC_ACCEPTED).c_str(),
@@ -83,9 +82,8 @@ void DeviceDefenderFeature::stopDeviceDefender()
 {
     LOGM_INFO(TAG, "Stopping %s", getName().c_str());
     task->StopTask();
-    auto onUnsubscribe = [&](MqttConnection &connection, uint16_t packetId, int errorCode) -> void {
-        LOGM_DEBUG(TAG, "Unsubscribing: PacketId:%i, ErrorCode:%i", packetId, errorCode);
-    };
+    auto onUnsubscribe = [&](MqttConnection &connection, uint16_t packetId, int errorCode) -> void
+    { LOGM_DEBUG(TAG, "Unsubscribing: PacketId:%i, ErrorCode:%i", packetId, errorCode); };
     const char *messageFormat = "%s%s%s%s";
     resourceManager->getConnection()->Unsubscribe(
         FormatMessage(messageFormat, TOPIC_PRE, thingName.c_str(), TOPIC_POST, TOPIC_ACCEPTED).c_str(), onUnsubscribe);

--- a/source/fleetprovisioning/FleetProvisioning.cpp
+++ b/source/fleetprovisioning/FleetProvisioning.cpp
@@ -37,7 +37,8 @@ constexpr int FleetProvisioning::DEFAULT_WAIT_TIME_SECONDS;
 bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient identityClient)
 {
     LOG_INFO(TAG, "Provisioning new device certificate and private key using CreateKeysAndCertificate API");
-    auto onKeysAcceptedSubAck = [&](int ioErr) {
+    auto onKeysAcceptedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -49,7 +50,8 @@ bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient i
         keysAcceptedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onKeysRejectedSubAck = [&](int ioErr) {
+    auto onKeysRejectedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -61,7 +63,8 @@ bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient i
         keysRejectedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onKeysPublishSubAck = [&](int ioErr) {
+    auto onKeysPublishSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -73,7 +76,8 @@ bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient i
         keysPublishCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onKeysAccepted = [&](CreateKeysAndCertificateResponse *response, int ioErr) {
+    auto onKeysAccepted = [&](CreateKeysAndCertificateResponse *response, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_INFO(TAG, "CreateKeysAndCertificateResponse certificateId: %s.", response->CertificateId->c_str());
@@ -129,7 +133,8 @@ bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient i
         }
     };
 
-    auto onKeysRejected = [&](ErrorResponse *error, int ioErr) {
+    auto onKeysRejected = [&](ErrorResponse *error, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -204,7 +209,8 @@ bool FleetProvisioning::CreateCertificateAndKey(Iotidentity::IotIdentityClient i
 bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient identityClient)
 {
     LOG_INFO(TAG, "Provisioning new device certificate using CreateCertificateFromCsr API");
-    auto onCsrAcceptedSubAck = [&](int ioErr) {
+    auto onCsrAcceptedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -216,7 +222,8 @@ bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient
         csrAcceptedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onCsrRejectedSubAck = [&](int ioErr) {
+    auto onCsrRejectedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -228,7 +235,8 @@ bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient
         csrRejectedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onCsrPublishSubAck = [&](int ioErr) {
+    auto onCsrPublishSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -240,7 +248,8 @@ bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient
         csrPublishCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onCsrAccepted = [&](CreateCertificateFromCsrResponse *response, int ioErr) {
+    auto onCsrAccepted = [&](CreateCertificateFromCsrResponse *response, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_INFO(TAG, "CreateCertificateFromCsrResponse certificateId: %s. ***", response->CertificateId->c_str());
@@ -284,7 +293,8 @@ bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient
         }
     };
 
-    auto onCsrRejected = [&](ErrorResponse *error, int ioErr) {
+    auto onCsrRejected = [&](ErrorResponse *error, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -362,7 +372,8 @@ bool FleetProvisioning::CreateCertificateUsingCSR(Iotidentity::IotIdentityClient
 }
 bool FleetProvisioning::RegisterThing(Iotidentity::IotIdentityClient identityClient)
 {
-    auto onRegisterAcceptedSubAck = [&](int ioErr) {
+    auto onRegisterAcceptedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -374,7 +385,8 @@ bool FleetProvisioning::RegisterThing(Iotidentity::IotIdentityClient identityCli
         registerAcceptedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onRegisterRejectedSubAck = [&](int ioErr) {
+    auto onRegisterRejectedSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -386,7 +398,8 @@ bool FleetProvisioning::RegisterThing(Iotidentity::IotIdentityClient identityCli
         registerRejectedCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onRegisterPublishSubAck = [&](int ioErr) {
+    auto onRegisterPublishSubAck = [&](int ioErr)
+    {
         if (ioErr != AWS_OP_SUCCESS)
         {
             LOGM_ERROR(
@@ -398,7 +411,8 @@ bool FleetProvisioning::RegisterThing(Iotidentity::IotIdentityClient identityCli
         registerPublishCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onRegisterAccepted = [&](RegisterThingResponse *response, int ioErr) {
+    auto onRegisterAccepted = [&](RegisterThingResponse *response, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_INFO(TAG, "RegisterThingResponse ThingName: %s.", response->ThingName->c_str());
@@ -413,7 +427,8 @@ bool FleetProvisioning::RegisterThing(Iotidentity::IotIdentityClient identityCli
         registerThingCompletedPromise.set_value(ioErr == AWS_OP_SUCCESS);
     };
 
-    auto onRegisterRejected = [&](ErrorResponse *error, int ioErr) {
+    auto onRegisterRejected = [&](ErrorResponse *error, int ioErr)
+    {
         if (ioErr == AWS_OP_SUCCESS)
         {
             LOGM_ERROR(

--- a/source/jobs/JobsFeature.cpp
+++ b/source/jobs/JobsFeature.cpp
@@ -423,7 +423,8 @@ void JobsFeature::publishUpdateJobExecutionStatus(
 
     // NOTE(marcoaz): statusDetails is captured by value
     // cppcheck-suppress danglingTemporaryLifetime
-    auto publishLambda = [this, data, statusInfo, statusDetails]() -> bool {
+    auto publishLambda = [this, data, statusInfo, statusDetails]() -> bool
+    {
         // We first need to make sure that we haven't previously leaked any promises into our map
         unique_lock<mutex> leakLock(updateJobExecutionPromisesLock);
         for (auto keyPromise = updateJobExecutionPromises.cbegin(); keyPromise != updateJobExecutionPromises.cend();
@@ -514,11 +515,13 @@ void JobsFeature::publishUpdateJobExecutionStatus(
         this->updateJobExecutionPromises.erase(clientToken.c_str());
         return finished;
     };
-    std::thread updateJobExecutionThread([retryConfig, publishLambda, onCompleteCallback] {
-        // NOTE(marcoaz): publishLambda is captured by value
-        // cppcheck-suppress danglingTemporaryLifetime
-        Retry::exponentialBackoff(retryConfig, publishLambda, onCompleteCallback);
-    });
+    std::thread updateJobExecutionThread(
+        [retryConfig, publishLambda, onCompleteCallback]
+        {
+            // NOTE(marcoaz): publishLambda is captured by value
+            // cppcheck-suppress danglingTemporaryLifetime
+            Retry::exponentialBackoff(retryConfig, publishLambda, onCompleteCallback);
+        });
     updateJobExecutionThread.detach();
 }
 
@@ -568,7 +571,8 @@ void JobsFeature::executeJob(JobExecutionData job)
 {
     LOGM_INFO(TAG, "Executing job: %s", job.JobId->c_str());
 
-    auto shutdownHandler = [this]() -> void {
+    auto shutdownHandler = [this]() -> void
+    {
         handlingJob.store(false);
         if (needStop.load())
         {
@@ -596,7 +600,8 @@ void JobsFeature::executeJob(JobExecutionData job)
     }
 
     // TODO: Add support for checking condition
-    auto runJob = [this, job, jobDocument, shutdownHandler]() {
+    auto runJob = [this, job, jobDocument, shutdownHandler]()
+    {
         JobEngine engine;
         // execute all action steps in sequence as provided in job document
         int executionStatus = engine.exec_steps(jobDocument, jobHandlerDir);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -198,7 +198,8 @@ void handle_feature_stopped(const Feature *feature)
 void attemptConnection()
 {
     Retry::ExponentialRetryConfig retryConfig = {10 * 1000, 900 * 1000, -1, nullptr};
-    auto publishLambda = []() -> bool {
+    auto publishLambda = []() -> bool
+    {
         int connectionStatus = resourceManager.get()->establishConnection(config.config);
         if (SharedCrtResourceManager::ABORT == connectionStatus)
         {
@@ -221,8 +222,8 @@ void attemptConnection()
             return false;
         }
     };
-    std::thread attemptConnectionThread(
-        [retryConfig, publishLambda] { Retry::exponentialBackoff(retryConfig, publishLambda); });
+    std::thread attemptConnectionThread([retryConfig, publishLambda]
+                                        { Retry::exponentialBackoff(retryConfig, publishLambda); });
     attemptConnectionThread.join();
 }
 

--- a/source/samples/pubsub/PubSubFeature.cpp
+++ b/source/samples/pubsub/PubSubFeature.cpp
@@ -166,7 +166,8 @@ void PubSubFeature::publishFileData()
         LOG_ERROR(TAG, "Failed to read publish file... Skipping publish");
         return;
     }
-    auto onPublishComplete = [payload, this](Mqtt::MqttConnection &, uint16_t packetId, int errorCode) mutable {
+    auto onPublishComplete = [payload, this](Mqtt::MqttConnection &, uint16_t packetId, int errorCode) mutable
+    {
         LOGM_DEBUG(TAG, "PublishCompAck: PacketId:(%s), ErrorCode:%d", getName().c_str(), errorCode);
         aws_byte_buf_clean_up_secure(&payload);
     };
@@ -179,10 +180,10 @@ int PubSubFeature::start()
     LOGM_INFO(TAG, "Starting %s", getName().c_str());
 
     auto onSubAck =
-        [&](MqttConnection &connection, uint16_t packetId, const String &topic, QOS qos, int errorCode) -> void {
-        LOGM_DEBUG(TAG, "SubAck: PacketId:(%s), ErrorCode:%d", getName().c_str(), errorCode);
-    };
-    auto onRecvData = [&](MqttConnection &connection, const String &topic, const ByteBuf &payload) -> void {
+        [&](MqttConnection &connection, uint16_t packetId, const String &topic, QOS qos, int errorCode) -> void
+    { LOGM_DEBUG(TAG, "SubAck: PacketId:(%s), ErrorCode:%d", getName().c_str(), errorCode); };
+    auto onRecvData = [&](MqttConnection &connection, const String &topic, const ByteBuf &payload) -> void
+    {
         LOGM_DEBUG(TAG, "Message received on subscribe topic, size: %zu bytes", payload.len);
         if (string((char *)payload.buffer, payload.len) == PUBLISH_TRIGGER_PAYLOAD)
         {
@@ -209,9 +210,8 @@ int PubSubFeature::start()
 
 int PubSubFeature::stop()
 {
-    auto onUnsubscribe = [&](MqttConnection &connection, uint16_t packetId, int errorCode) -> void {
-        LOGM_DEBUG(TAG, "Unsubscribing: PacketId:%u, ErrorCode:%d", packetId, errorCode);
-    };
+    auto onUnsubscribe = [&](MqttConnection &connection, uint16_t packetId, int errorCode) -> void
+    { LOGM_DEBUG(TAG, "Unsubscribing: PacketId:%u, ErrorCode:%d", packetId, errorCode); };
 
     resourceManager->getConnection()->Unsubscribe(subTopic.c_str(), onUnsubscribe);
     baseNotifier->onEvent((Feature *)this, ClientBaseEventNotification::FEATURE_STOPPED);

--- a/source/sensor-publish/HeartbeatTask.cpp
+++ b/source/sensor-publish/HeartbeatTask.cpp
@@ -37,7 +37,8 @@ HeartbeatTask::HeartbeatTask(
     AWS_ZERO_STRUCT(mTask);
     aws_task_init(
         &mTask,
-        [](struct aws_task *task, void *arg, enum aws_task_status status) {
+        [](struct aws_task *task, void *arg, enum aws_task_status status)
+        {
             if (status == AWS_TASK_STATUS_CANCELED)
             {
                 return; // Ignore canceled tasks.
@@ -127,7 +128,8 @@ void HeartbeatTask::publish()
         AWS_MQTT_QOS_AT_LEAST_ONCE,
         false,
         &mPayload,
-        [](struct aws_mqtt_client_connection *connection, uint16_t packet_id, int error_code, void *userdata) {
+        [](struct aws_mqtt_client_connection *connection, uint16_t packet_id, int error_code, void *userdata)
+        {
             auto *self = static_cast<HeartbeatTask *>(userdata);
             if (error_code)
             {

--- a/source/sensor-publish/Sensor.cpp
+++ b/source/sensor-publish/Sensor.cpp
@@ -56,7 +56,8 @@ Sensor::Sensor(
     AWS_ZERO_STRUCT(mConnectTask);
     aws_task_init(
         &mConnectTask,
-        [](struct aws_task *task, void *arg, enum aws_task_status status) {
+        [](struct aws_task *task, void *arg, enum aws_task_status status)
+        {
             if (status == AWS_TASK_STATUS_CANCELED)
             {
                 return; // Ignore canceled tasks.
@@ -151,7 +152,8 @@ void Sensor::onConnectTaskCallback()
     int rc = mSocket->connect(
         &endpoint,
         mEventLoop,
-        [](struct aws_socket *, int error_code, void *user_data) {
+        [](struct aws_socket *, int error_code, void *user_data)
+        {
             auto *self = static_cast<Sensor *>(user_data);
             self->onConnectionResultCallback(error_code);
         },
@@ -205,7 +207,8 @@ void Sensor::onConnectionResultCallback(int error_code)
 
         // Register callback that will be invoked when the socket is readable.
         mSocket->subscribe_to_readable_events(
-            [](struct aws_socket *, int error_code, void *user_data) {
+            [](struct aws_socket *, int error_code, void *user_data)
+            {
                 auto *self = static_cast<Sensor *>(user_data);
                 self->onReadableCallback(error_code);
             },
@@ -400,7 +403,8 @@ void Sensor::publishOneMessage(const aws_byte_cursor *payload)
         AWS_MQTT_QOS_AT_LEAST_ONCE,
         false,
         payload,
-        [](struct aws_mqtt_client_connection *connection, uint16_t packet_id, int error_code, void *userdata) {
+        [](struct aws_mqtt_client_connection *connection, uint16_t packet_id, int error_code, void *userdata)
+        {
             auto *self = static_cast<Sensor *>(userdata);
             if (error_code)
             {

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -33,7 +33,10 @@ namespace Aws
                 {
                 }
 
-                SecureTunnelingContext::~SecureTunnelingContext() { mSecureTunnel->Close(); }
+                SecureTunnelingContext::~SecureTunnelingContext()
+                {
+                    mSecureTunnel->Close();
+                }
 
                 template <typename T>
                 static bool operator==(const Aws::Crt::Optional<T> &lhs, const Aws::Crt::Optional<T> &rhs)
@@ -128,7 +131,10 @@ namespace Aws
                     mTcpForward->Connect();
                 }
 
-                void SecureTunnelingContext::DisconnectFromTcpForward() { mTcpForward.reset(); }
+                void SecureTunnelingContext::DisconnectFromTcpForward()
+                {
+                    mTcpForward.reset();
+                }
 
                 void SecureTunnelingContext::OnConnectionComplete()
                 {

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -31,7 +31,10 @@ namespace Aws
 
                 SecureTunnelingFeature::SecureTunnelingFeature() = default;
 
-                SecureTunnelingFeature::~SecureTunnelingFeature() { aws_http_library_clean_up(); }
+                SecureTunnelingFeature::~SecureTunnelingFeature()
+                {
+                    aws_http_library_clean_up();
+                }
 
                 int SecureTunnelingFeature::init(
                     shared_ptr<SharedCrtResourceManager> sharedCrtResourceManager,
@@ -50,7 +53,10 @@ namespace Aws
                     return 0;
                 }
 
-                string SecureTunnelingFeature::getName() { return "Secure Tunneling"; }
+                string SecureTunnelingFeature::getName()
+                {
+                    return "Secure Tunneling";
+                }
 
                 int SecureTunnelingFeature::start()
                 {
@@ -90,7 +96,10 @@ namespace Aws
                     return result->second;
                 }
 
-                bool SecureTunnelingFeature::IsValidPort(int port) { return 1 <= port && port <= 65535; }
+                bool SecureTunnelingFeature::IsValidPort(int port)
+                {
+                    return 1 <= port && port <= 65535;
+                }
 
                 void SecureTunnelingFeature::LoadFromConfig(const PlainConfig &config)
                 {
@@ -261,9 +270,10 @@ namespace Aws
                 {
                     LOG_DEBUG(TAG, "SecureTunnelingFeature::OnConnectionShutdown");
 
-                    auto it = find_if(mContexts.begin(), mContexts.end(), [&](unique_ptr<SecureTunnelingContext> &c) {
-                        return c.get() == contextToRemove;
-                    });
+                    auto it = find_if(
+                        mContexts.begin(),
+                        mContexts.end(),
+                        [&](unique_ptr<SecureTunnelingContext> &c) { return c.get() == contextToRemove; });
                     mContexts.erase(std::remove(mContexts.begin(), mContexts.end(), *it));
 
 #if defined(DISABLE_MQTT)

--- a/source/util/StringUtils.cpp
+++ b/source/util/StringUtils.cpp
@@ -93,9 +93,15 @@ namespace Aws
                 }
 
                 // cppcheck-suppress unusedFunction
-                string TrimLeftCopy(string s, const string &any) { return s.erase(0, s.find_first_not_of(any)); }
+                string TrimLeftCopy(string s, const string &any)
+                {
+                    return s.erase(0, s.find_first_not_of(any));
+                }
 
-                string TrimRightCopy(string s, const string &any) { return s.erase(s.find_last_not_of(any) + 1); }
+                string TrimRightCopy(string s, const string &any)
+                {
+                    return s.erase(s.find_last_not_of(any) + 1);
+                }
 
                 // cppcheck-suppress unusedFunction
                 string TrimCopy(string s, const string &any)


### PR DESCRIPTION
### Motivation
clang-format check was giving false positive format errors.


### Modifications
#### Change summary
Changed workflow to use the format-check script. Formatted all files that were throwing format errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
