### PR TITLE
Refactor Jobs and add unit tests

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -434,19 +434,19 @@ int PlainConfig::LogConfig::ParseDeviceClientLogLevel(string level)
 
     if ("DEBUG" == temp)
     {
-        return (int)LogLevel::DEBUG;
+        return (int)Aws::Iot::DeviceClient::Logging::LogLevel::DEBUG;
     }
     else if ("INFO" == temp)
     {
-        return (int)LogLevel::INFO;
+        return (int)Aws::Iot::DeviceClient::Logging::LogLevel::INFO;
     }
     else if ("WARN" == temp)
     {
-        return (int)LogLevel::WARN;
+        return (int)Aws::Iot::DeviceClient::Logging::LogLevel::WARN;
     }
     else if ("ERROR" == temp)
     {
-        return (int)LogLevel::ERROR;
+        return (int)Aws::Iot::DeviceClient::Logging::LogLevel::ERROR;
     }
     else
     {

--- a/source/jobs/IotJobsClientWrapper.cpp
+++ b/source/jobs/IotJobsClientWrapper.cpp
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "IotJobsClientWrapper.h"
+#include "JobsFeature.h"
+#include "aws/iotjobs/NextJobExecutionChangedSubscriptionRequest.h"
+#include "aws/iotjobs/StartNextPendingJobExecutionRequest.h"
+#include "aws/iotjobs/StartNextPendingJobExecutionSubscriptionRequest.h"
+#include "aws/iotjobs/UpdateJobExecutionRequest.h"
+#include "aws/iotjobs/UpdateJobExecutionSubscriptionRequest.h"
+
+using namespace std;
+using namespace Aws::Iot;
+using namespace Aws::Iot::DeviceClient;
+using namespace Aws::Iot::DeviceClient::Jobs;
+using namespace Aws::Iotjobs;
+
+IotJobsClientWrapper::IotJobsClientWrapper(
+    const std::string &thingName,
+    const std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection)
+    : thingName(thingName), mqttConnection(connection)
+{
+    jobsClient = std::unique_ptr<Aws::Iotjobs::IotJobsClient>(new IotJobsClient(mqttConnection));
+}
+void IotJobsClientWrapper::PublishStartNextPendingJobExecution(
+    const StartNextPendingJobExecutionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnPublishComplete &onPubAck)
+{
+    jobsClient->PublishStartNextPendingJobExecution(request, qos, onPubAck);
+}
+void IotJobsClientWrapper::SubscribeToStartNextPendingJobExecutionAccepted(
+    const StartNextPendingJobExecutionSubscriptionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnSubscribeToStartNextPendingJobExecutionAcceptedResponse &handler,
+    const OnSubscribeComplete &onSubAck)
+{
+    jobsClient->SubscribeToStartNextPendingJobExecutionAccepted(request, qos, handler, onSubAck);
+}
+void IotJobsClientWrapper::SubscribeToStartNextPendingJobExecutionRejected(
+    const StartNextPendingJobExecutionSubscriptionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnSubscribeToStartNextPendingJobExecutionRejectedResponse &handler,
+    const OnSubscribeComplete &onSubAck)
+{
+    jobsClient->SubscribeToStartNextPendingJobExecutionRejected(request, qos, handler, onSubAck);
+}
+void IotJobsClientWrapper::SubscribeToNextJobExecutionChangedEvents(
+    const NextJobExecutionChangedSubscriptionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnSubscribeToNextJobExecutionChangedEventsResponse &handler,
+    const OnSubscribeComplete &onSubAck)
+{
+    jobsClient->SubscribeToNextJobExecutionChangedEvents(request, qos, handler, onSubAck);
+}
+void IotJobsClientWrapper::SubscribeToUpdateJobExecutionAccepted(
+    const UpdateJobExecutionSubscriptionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnSubscribeToUpdateJobExecutionAcceptedResponse &handler,
+    const OnSubscribeComplete &onSubAck)
+{
+    jobsClient->SubscribeToUpdateJobExecutionAccepted(request, qos, handler, onSubAck);
+}
+void IotJobsClientWrapper::SubscribeToUpdateJobExecutionRejected(
+    const UpdateJobExecutionSubscriptionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnSubscribeToUpdateJobExecutionRejectedResponse &handler,
+    const OnSubscribeComplete &onSubAck)
+{
+    jobsClient->SubscribeToUpdateJobExecutionRejected(request, qos, handler, onSubAck);
+}
+void IotJobsClientWrapper::PublishUpdateJobExecution(
+    const UpdateJobExecutionRequest &request,
+    Aws::Crt::Mqtt::QOS qos,
+    const OnPublishComplete &onPubAck)
+{
+    jobsClient->PublishUpdateJobExecution(request, qos, onPubAck);
+}

--- a/source/jobs/IotJobsClientWrapper.cpp
+++ b/source/jobs/IotJobsClientWrapper.cpp
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "IotJobsClientWrapper.h"
-#include "JobsFeature.h"
-#include "aws/iotjobs/NextJobExecutionChangedSubscriptionRequest.h"
-#include "aws/iotjobs/StartNextPendingJobExecutionRequest.h"
-#include "aws/iotjobs/StartNextPendingJobExecutionSubscriptionRequest.h"
-#include "aws/iotjobs/UpdateJobExecutionRequest.h"
-#include "aws/iotjobs/UpdateJobExecutionSubscriptionRequest.h"
+#include <aws/iotjobs/NextJobExecutionChangedSubscriptionRequest.h>
+#include <aws/iotjobs/StartNextPendingJobExecutionRequest.h>
+#include <aws/iotjobs/StartNextPendingJobExecutionSubscriptionRequest.h>
+#include <aws/iotjobs/UpdateJobExecutionRequest.h>
+#include <aws/iotjobs/UpdateJobExecutionSubscriptionRequest.h>
 
 using namespace std;
 using namespace Aws::Iot;
@@ -15,12 +14,9 @@ using namespace Aws::Iot::DeviceClient;
 using namespace Aws::Iot::DeviceClient::Jobs;
 using namespace Aws::Iotjobs;
 
-IotJobsClientWrapper::IotJobsClientWrapper(
-    const std::string &thingName,
-    const std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection)
-    : thingName(thingName), mqttConnection(connection)
+IotJobsClientWrapper::IotJobsClientWrapper(std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection)
+    : jobsClient(std::unique_ptr<Aws::Iotjobs::IotJobsClient>(new IotJobsClient(connection)))
 {
-    jobsClient = std::unique_ptr<Aws::Iotjobs::IotJobsClient>(new IotJobsClient(mqttConnection));
 }
 void IotJobsClientWrapper::PublishStartNextPendingJobExecution(
     const StartNextPendingJobExecutionRequest &request,

--- a/source/jobs/IotJobsClientWrapper.h
+++ b/source/jobs/IotJobsClientWrapper.h
@@ -1,10 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef AWS_IOT_DEVICE_CLIENT_IOTJOBSCLIENTWRAPPER_H
 #define AWS_IOT_DEVICE_CLIENT_IOTJOBSCLIENTWRAPPER_H
 
 #include "../SharedCrtResourceManager.h"
 #include "JobsFeature.h"
-#include "aws/iotjobs/JobStatus.h"
 #include <aws/iotjobs/IotJobsClient.h>
+#include <aws/iotjobs/JobStatus.h>
+#include <memory>
+#include <string>
 
 namespace Aws
 {
@@ -62,10 +67,7 @@ namespace Aws
                 class IotJobsClientWrapper : public AbstractIotJobsClient
                 {
                   public:
-                    IotJobsClientWrapper() = default;
-                    IotJobsClientWrapper(
-                        const std::string &thingName,
-                        const std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection);
+                    explicit IotJobsClientWrapper(std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection);
                     void PublishStartNextPendingJobExecution(
                         const Iotjobs::StartNextPendingJobExecutionRequest &request,
                         Aws::Crt::Mqtt::QOS qos,
@@ -107,8 +109,6 @@ namespace Aws
                         const Iotjobs::OnPublishComplete &onPubAck) override;
 
                   private:
-                    std::string thingName;
-                    std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> mqttConnection;
                     std::unique_ptr<Aws::Iotjobs::IotJobsClient> jobsClient;
                 };
             } // namespace Jobs

--- a/source/jobs/IotJobsClientWrapper.h
+++ b/source/jobs/IotJobsClientWrapper.h
@@ -1,0 +1,119 @@
+#ifndef AWS_IOT_DEVICE_CLIENT_IOTJOBSCLIENTWRAPPER_H
+#define AWS_IOT_DEVICE_CLIENT_IOTJOBSCLIENTWRAPPER_H
+
+#include "../SharedCrtResourceManager.h"
+#include "JobsFeature.h"
+#include "aws/iotjobs/JobStatus.h"
+#include <aws/iotjobs/IotJobsClient.h>
+
+namespace Aws
+{
+    namespace Iot
+    {
+        namespace DeviceClient
+        {
+            namespace Jobs
+            {
+                class AbstractIotJobsClient
+                {
+                  public:
+                    virtual ~AbstractIotJobsClient() = default;
+                    virtual void PublishStartNextPendingJobExecution(
+                        const Iotjobs::StartNextPendingJobExecutionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnPublishComplete &onPubAck) = 0;
+
+                    virtual void SubscribeToStartNextPendingJobExecutionAccepted(
+                        const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToStartNextPendingJobExecutionAcceptedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) = 0;
+
+                    virtual void SubscribeToStartNextPendingJobExecutionRejected(
+                        const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToStartNextPendingJobExecutionRejectedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) = 0;
+
+                    virtual void SubscribeToNextJobExecutionChangedEvents(
+                        const Iotjobs::NextJobExecutionChangedSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToNextJobExecutionChangedEventsResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) = 0;
+
+                    virtual void SubscribeToUpdateJobExecutionAccepted(
+                        const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToUpdateJobExecutionAcceptedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) = 0;
+
+                    virtual void SubscribeToUpdateJobExecutionRejected(
+                        const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToUpdateJobExecutionRejectedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) = 0;
+
+                    virtual void PublishUpdateJobExecution(
+                        const Iotjobs::UpdateJobExecutionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnPublishComplete &onPubAck) = 0;
+                };
+
+                class IotJobsClientWrapper : public AbstractIotJobsClient
+                {
+                  public:
+                    IotJobsClientWrapper() = default;
+                    IotJobsClientWrapper(
+                        const std::string &thingName,
+                        const std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection);
+                    void PublishStartNextPendingJobExecution(
+                        const Iotjobs::StartNextPendingJobExecutionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnPublishComplete &onPubAck) override;
+
+                    void SubscribeToStartNextPendingJobExecutionAccepted(
+                        const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToStartNextPendingJobExecutionAcceptedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) override;
+
+                    void SubscribeToStartNextPendingJobExecutionRejected(
+                        const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToStartNextPendingJobExecutionRejectedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) override;
+
+                    void SubscribeToNextJobExecutionChangedEvents(
+                        const Iotjobs::NextJobExecutionChangedSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToNextJobExecutionChangedEventsResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) override;
+
+                    void SubscribeToUpdateJobExecutionAccepted(
+                        const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToUpdateJobExecutionAcceptedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) override;
+
+                    void SubscribeToUpdateJobExecutionRejected(
+                        const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnSubscribeToUpdateJobExecutionRejectedResponse &handler,
+                        const Iotjobs::OnSubscribeComplete &onSubAck) override;
+
+                    void PublishUpdateJobExecution(
+                        const Iotjobs::UpdateJobExecutionRequest &request,
+                        Aws::Crt::Mqtt::QOS qos,
+                        const Iotjobs::OnPublishComplete &onPubAck) override;
+
+                  private:
+                    std::string thingName;
+                    std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> mqttConnection;
+                    std::unique_ptr<Aws::Iotjobs::IotJobsClient> jobsClient;
+                };
+            } // namespace Jobs
+        }     // namespace DeviceClient
+    }         // namespace Iot
+} // namespace Aws
+
+#endif // AWS_IOT_DEVICE_CLIENT_IOTJOBSCLIENTWRAPPER_H

--- a/source/jobs/JobsFeature.cpp
+++ b/source/jobs/JobsFeature.cpp
@@ -431,8 +431,6 @@ void JobsFeature::publishUpdateJobExecutionStatusWithRetry(
         retryConfig.needStopFlag = nullptr;
     }
 
-    // NOTE(marcoaz): statusDetails is captured by value
-    // cppcheck-suppress danglingTemporaryLifetime
     auto publishLambda = [this, data, statusInfo, statusDetails]() -> bool {
         // We first need to make sure that we haven't previously leaked any promises into our map
         unique_lock<mutex> leakLock(updateJobExecutionPromisesLock);
@@ -522,8 +520,6 @@ void JobsFeature::publishUpdateJobExecutionStatusWithRetry(
         return finished;
     };
     std::thread updateJobExecutionThread([retryConfig, publishLambda, onCompleteCallback] {
-        // NOTE(marcoaz): publishLambda is captured by value
-        // cppcheck-suppress danglingTemporaryLifetime
         Retry::exponentialBackoff(retryConfig, publishLambda, onCompleteCallback);
     });
     updateJobExecutionThread.detach();

--- a/source/jobs/JobsFeature.cpp
+++ b/source/jobs/JobsFeature.cpp
@@ -241,7 +241,7 @@ void JobsFeature::startNextPendingJobReceivedHandler(StartNextJobExecutionRespon
                 handlingJob.store(true);
 
                 copyJobsNotification(response->Execution.value());
-                executeJob(response->Execution.value());
+                initJob(response->Execution.value());
             }
         }
     }
@@ -292,7 +292,7 @@ void JobsFeature::nextJobChangedHandler(NextJobExecutionChangedEvent *event, int
                 handlingJob.store(true);
 
                 copyJobsNotification(event->Execution.value());
-                executeJob(event->Execution.value());
+                initJob(event->Execution.value());
             }
         }
     }
@@ -407,7 +407,17 @@ void JobsFeature::publishUpdateJobExecutionStatus(
     {
         LOG_DEBUG(TAG, "Not including stderr with the status details");
     }
+    // NOTE(marcoaz): statusDetails is captured by value
+    // cppcheck-suppress danglingTemporaryLifetime
+    publishUpdateJobExecutionStatusWithRetry(data, statusInfo, statusDetails, onCompleteCallback);
+}
 
+void JobsFeature::publishUpdateJobExecutionStatusWithRetry(
+    Aws::Iotjobs::JobExecutionData data,
+    JobsFeature::JobExecutionStatusInfo statusInfo,
+    Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> statusDetails,
+    std::function<void(void)> onCompleteCallback)
+{
     /** When we update the job execution status, we need to perform an exponential
      * backoff in case our request gets throttled. Otherwise, if we never properly
      * update the job execution status, we'll never receive the next job
@@ -448,13 +458,10 @@ void JobsFeature::publishUpdateJobExecutionStatus(
         request.JobId = data.JobId->c_str();
         request.ThingName = this->thingName.c_str();
         request.Status = statusInfo.status;
-        // cppcheck-suppress danglingTemporaryLifetime
         request.StatusDetails = statusDetails;
 
         // Create a unique client token each time we attempt the request since the promise has to be fresh
         string clientToken = UniqueString::GetRandomToken(10);
-        // NOTE(marcoaz): Aws::Crt::String does not convert from std::string
-        // cppcheck-suppress danglingTemporaryLifetime
         request.ClientToken = Aws::Crt::Optional<Aws::Crt::String>(clientToken.c_str());
         unique_lock<mutex> writeLock(updateJobExecutionPromisesLock);
         this->updateJobExecutionPromises.insert(
@@ -564,7 +571,7 @@ bool JobsFeature::isDuplicateNotification(JobExecutionData job)
     return true;
 }
 
-void JobsFeature::executeJob(JobExecutionData job)
+void JobsFeature::initJob(const JobExecutionData &job)
 {
     LOGM_INFO(TAG, "Executing job: %s", job.JobId->c_str());
 
@@ -576,10 +583,10 @@ void JobsFeature::executeJob(JobExecutionData job)
             baseNotifier->onEvent((Feature *)this, ClientBaseEventNotification::FEATURE_STOPPED);
         }
     };
+
     Aws::Crt::JsonView jobDoc = job.JobDocument->View();
     PlainJobDocument jobDocument;
     // reject job document based on the validation status
-    // TODO: create init method and call it instead
     jobDocument.LoadFromJobDocument(jobDoc);
     if (!jobDocument.Validate())
     {
@@ -590,11 +597,23 @@ void JobsFeature::executeJob(JobExecutionData job)
             shutdownHandler);
         return;
     }
-    else
-    {
-        publishUpdateJobExecutionStatus(job, {Iotjobs::JobStatus::IN_PROGRESS, "", "", ""});
-    }
+    publishUpdateJobExecutionStatus(job, {Iotjobs::JobStatus::IN_PROGRESS, "", "", ""});
+    executeJob(job, jobDocument);
+}
 
+void JobsFeature::executeJob(const Iotjobs::JobExecutionData &job, const PlainJobDocument &jobDocument)
+{
+    LOGM_INFO(TAG, "Executing job: %s", job.JobId->c_str());
+
+    auto shutdownHandler = [this]() -> void
+    {
+        handlingJob.store(false);
+        if (needStop.load())
+        {
+            LOGM_INFO(TAG, "Shutting down %s now that job execution is complete", getName().c_str());
+            baseNotifier->onEvent((Feature *)this, ClientBaseEventNotification::FEATURE_STOPPED);
+        }
+    };
     // TODO: Add support for checking condition
     auto runJob = [this, job, jobDocument, shutdownHandler]() {
         JobEngine engine;
@@ -632,7 +651,7 @@ void JobsFeature::runJobs()
 {
     LOGM_INFO(TAG, "Running %s!", getName().c_str());
 
-    jobsClient = unique_ptr<IotJobsClient>(new IotJobsClient(resourceManager.get()->getConnection()));
+    jobsClient = getJobsClient();
 
     // Create subscriptions to important MQTT topics
     subscribeToStartNextPendingJobExecution();
@@ -646,11 +665,11 @@ void JobsFeature::runJobs()
 }
 
 int JobsFeature::init(
-    shared_ptr<SharedCrtResourceManager> manager,
+    shared_ptr<Mqtt::MqttConnection> connection,
     shared_ptr<ClientBaseNotifier> notifier,
     const PlainConfig &config)
 {
-    resourceManager = manager;
+    mqttConnection = connection;
     baseNotifier = notifier;
     thingName = config.thingName->c_str();
 
@@ -688,4 +707,9 @@ int JobsFeature::stop()
     }
 
     return 0;
+}
+
+std::shared_ptr<AbstractIotJobsClient> JobsFeature::getJobsClient()
+{
+    return std::shared_ptr<AbstractIotJobsClient>(new IotJobsClientWrapper(thingName, mqttConnection));
 }

--- a/source/jobs/JobsFeature.cpp
+++ b/source/jobs/JobsFeature.cpp
@@ -605,8 +605,7 @@ void JobsFeature::executeJob(const Iotjobs::JobExecutionData &job, const PlainJo
 {
     LOGM_INFO(TAG, "Executing job: %s", job.JobId->c_str());
 
-    auto shutdownHandler = [this]() -> void
-    {
+    auto shutdownHandler = [this]() -> void {
         handlingJob.store(false);
         if (needStop.load())
         {

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -49,19 +49,19 @@ namespace Aws
                      */
                     struct JobExecutionStatusInfo
                     {
-                        Aws::Iotjobs::JobStatus status;
+                        Iotjobs::JobStatus status;
                         std::string reason;
-                        std::string stdoutput;
-                        std::string stderror;
+                        std::string output;
 
-                        explicit JobExecutionStatusInfo(
+                        JobExecutionStatusInfo(
                             Iotjobs::JobStatus status,
-                            const std::string &reason = "",
-                            const std::string &stdoutput = "",
-                            const std::string &stderror = "")
-                            : status(status), reason(reason), stdoutput(stdoutput), stderror(stderror)
+                            const std::string &reason,
+                            const std::string &output)
+                            : status(status), reason(reason), output(output)
                         {
                         }
+
+                        explicit JobExecutionStatusInfo(Iotjobs::JobStatus status) : status(status) {}
                     };
 
                   private:

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -12,6 +12,8 @@
 #include "../Feature.h"
 #include "../SharedCrtResourceManager.h"
 #include "EphemeralPromise.h"
+#include "IotJobsClientWrapper.h"
+#include "JobDocument.h"
 
 namespace Aws
 {
@@ -21,11 +23,38 @@ namespace Aws
         {
             namespace Jobs
             {
+                class AbstractIotJobsClient;
                 /**
                  * \brief Provides IoT Jobs related functionality within the Device Client
                  */
                 class JobsFeature : public Feature
                 {
+                  protected:
+                    /**
+                     * \brief Begins running the Jobs feature
+                     */
+                    void runJobs();
+                    /**
+                     * \brief An enum used for UpdateJobExecution responses
+                     */
+                    enum UpdateJobExecutionResponseType
+                    {
+                        ACCEPTED,
+                        RETRYABLE_ERROR,
+                        NON_RETRYABLE_ERROR
+                    };
+
+                    /**
+                     * \brief Wrapper struct to aggregate JobEngine output for updating a job execution status
+                     */
+                    struct JobExecutionStatusInfo
+                    {
+                        Aws::Iotjobs::JobStatus status;
+                        std::string reason;
+                        std::string stdoutput;
+                        std::string stderror;
+                    };
+
                   private:
                     /**
                      * \brief Used by the logger to specify that log messages are coming from the Jobs feature
@@ -58,16 +87,6 @@ namespace Aws
                     std::mutex updateJobExecutionPromisesLock;
 
                     /**
-                     * \brief An enum used for UpdateJobExecution responses
-                     */
-                    enum UpdateJobExecutionResponseType
-                    {
-                        ACCEPTED,
-                        RETRYABLE_ERROR,
-                        NON_RETRYABLE_ERROR
-                    };
-
-                    /**
                      * \brief Allows us to map UpdateJobExecution responses back to their original request
                      */
                     Aws::Crt::Map<
@@ -81,7 +100,7 @@ namespace Aws
                     /**
                      * \brief The resource manager used to manage CRT resources
                      */
-                    std::shared_ptr<SharedCrtResourceManager> resourceManager;
+                    std::shared_ptr<Crt::Mqtt::MqttConnection> mqttConnection;
                     /**
                      * \brief An interface used to notify the Client base if there is an event that requires its
                      * attention
@@ -91,7 +110,7 @@ namespace Aws
                     /**
                      * \brief an IotJobsClient used to make calls to the AWS IoT Jobs service
                      */
-                    std::unique_ptr<Aws::Iotjobs::IotJobsClient> jobsClient;
+                    std::shared_ptr<AbstractIotJobsClient> jobsClient;
 
                     /**
                      * \brief the ThingName to use
@@ -150,18 +169,7 @@ namespace Aws
                     /**
                      * \brief Publishes a request to startNextPendingJobExecution
                      */
-                    void publishStartNextPendingJobExecutionRequest();
-
-                    /**
-                     * \brief Wrapper struct to aggregate JobEngine output for updating a job execution status
-                     */
-                    struct JobExecutionStatusInfo
-                    {
-                        Aws::Iotjobs::JobStatus status;
-                        std::string reason;
-                        std::string stdoutput;
-                        std::string stderror;
-                    };
+                    virtual void publishStartNextPendingJobExecutionRequest();
 
                     /**
                      * \brief Attempts to update a job execution to the provided status
@@ -173,28 +181,34 @@ namespace Aws
                         Aws::Iotjobs::JobExecutionData data,
                         JobExecutionStatusInfo statusInfo,
                         std::function<void(void)> onCompleteCallback = nullptr);
+
+                    virtual void publishUpdateJobExecutionStatusWithRetry(
+                        Aws::Iotjobs::JobExecutionData data,
+                        JobExecutionStatusInfo statusInfo,
+                        Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> statusDetails,
+                        std::function<void(void)> onCompleteCallback);
                     /**
                      * \brief Creates a subscription to the startNextPendingJobExecution topic
                      */
-                    void subscribeToStartNextPendingJobExecution();
+                    virtual void subscribeToStartNextPendingJobExecution();
                     /**
                      * \brief Creates a subscription to NextJobChangedEvents
                      */
-                    void subscribeToNextJobChangedEvents();
+                    virtual void subscribeToNextJobChangedEvents();
                     /**
                      * \brief Enables the Jobs feature to receive response information from the IoT Jobs service when an
                      * update is accepted
                      * @param jobId the job ID to listen for. Use "+" to subscribe for all job executions for this
                      * thing.
                      */
-                    void subscribeToUpdateJobExecutionStatusAccepted(const std::string &jobId);
+                    virtual void subscribeToUpdateJobExecutionStatusAccepted(const std::string &jobId);
                     /**
                      * \brief Enables the Jobs feature to receive response information from the IoT Jobs service when an
                      * update is rejected
                      * @param jobId the job ID to listen for. Use "+" to subscribe for all job executions for this
                      * thing.
                      */
-                    void subscribeToUpdateJobExecutionStatusRejected(const std::string &jobId);
+                    virtual void subscribeToUpdateJobExecutionStatusRejected(const std::string &jobId);
 
                     // Incoming Mqtt message handlers
                     /**
@@ -203,7 +217,7 @@ namespace Aws
                      * @param response the response from Iot Core
                      * @param ioError a non-zero error code indicates a problem
                      */
-                    void startNextPendingJobReceivedHandler(
+                    virtual void startNextPendingJobReceivedHandler(
                         Iotjobs::StartNextJobExecutionResponse *response,
                         int ioError);
                     /**
@@ -212,7 +226,7 @@ namespace Aws
                      * @param rejectedError information about the rejection
                      * @param ioError a non-zero error code indicates a problem
                      */
-                    void startNextPendingJobRejectedHandler(Iotjobs::RejectedError *rejectedError, int ioError);
+                    virtual void startNextPendingJobRejectedHandler(Iotjobs::RejectedError *rejectedError, int ioError);
                     /**
                      * \brief Executed when the next job for this thing to execute has changed.
                      *
@@ -221,14 +235,14 @@ namespace Aws
                      * @param event information about the next job
                      * @param ioErr a non-zero error code indicates a problem
                      */
-                    void nextJobChangedHandler(Iotjobs::NextJobExecutionChangedEvent *event, int ioErr);
+                    virtual void nextJobChangedHandler(Iotjobs::NextJobExecutionChangedEvent *event, int ioErr);
                     /**
                      * A handler function called by the CRT SDK when we receive a response to our request to
                      * update a job execution status
                      * @param response information used to determine which job execution was updated
                      * @param ioError a non-zero error code indicates a problem
                      */
-                    void updateJobExecutionStatusAcceptedHandler(
+                    virtual void updateJobExecutionStatusAcceptedHandler(
                         Iotjobs::UpdateJobExecutionResponse *response,
                         int ioError);
                     /**
@@ -237,14 +251,18 @@ namespace Aws
                      * @param response information used to determine which job execution was updated
                      * @param ioError a non-zero error code indicates a problem
                      */
-                    void updateJobExecutionStatusRejectedHandler(Iotjobs::RejectedError *rejectedError, int ioError);
+                    virtual void updateJobExecutionStatusRejectedHandler(
+                        Iotjobs::RejectedError *rejectedError,
+                        int ioError);
 
                     /**
                      * \brief Called to begin the execution of a job on the device
                      *
                      * @param job the job to execute
                      */
-                    void executeJob(Iotjobs::JobExecutionData job);
+                    virtual void executeJob(const Iotjobs::JobExecutionData &job, const PlainJobDocument &jobDocument);
+
+                    void initJob(const Iotjobs::JobExecutionData &job);
 
                     /**
                      * \brief Given a job notification, determines whether it's a duplicate message.
@@ -264,10 +282,11 @@ namespace Aws
                      * @param job
                      */
                     void copyJobsNotification(Iotjobs::JobExecutionData job);
+
                     /**
-                     * \brief Begins running the Jobs feature
+                     * \brief Made virtual to facilitate injecting mock for testing
                      */
-                    void runJobs();
+                    virtual std::shared_ptr<AbstractIotJobsClient> getJobsClient();
 
                   public:
                     virtual std::string getName() override;
@@ -282,7 +301,7 @@ namespace Aws
                      * @return a non-zero return code indicates a problem. The logs can be checked for more info
                      */
                     virtual int init(
-                        std::shared_ptr<SharedCrtResourceManager> manager,
+                        std::shared_ptr<Crt::Mqtt::MqttConnection> connection,
                         std::shared_ptr<ClientBaseNotifier> notifier,
                         const PlainConfig &config);
 

--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -53,6 +53,15 @@ namespace Aws
                         std::string reason;
                         std::string stdoutput;
                         std::string stderror;
+
+                        explicit JobExecutionStatusInfo(
+                            Iotjobs::JobStatus status,
+                            const std::string &reason = "",
+                            const std::string &stdoutput = "",
+                            const std::string &stderror = "")
+                            : status(status), reason(reason), stdoutput(stdoutput), stderror(stderror)
+                        {
+                        }
                     };
 
                   private:
@@ -98,7 +107,7 @@ namespace Aws
                     Aws::Iotjobs::JobExecutionData latestJobsNotification;
 
                     /**
-                     * \brief The resource manager used to manage CRT resources
+                     * \brief Mqtt Connection for IotJobsClient
                      */
                     std::shared_ptr<Crt::Mqtt::MqttConnection> mqttConnection;
                     /**
@@ -286,7 +295,7 @@ namespace Aws
                     /**
                      * \brief Made virtual to facilitate injecting mock for testing
                      */
-                    virtual std::shared_ptr<AbstractIotJobsClient> getJobsClient();
+                    virtual std::shared_ptr<AbstractIotJobsClient> createJobsClient();
 
                   public:
                     virtual std::string getName() override;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
     {
         LOG_INFO(TAG, "Jobs is enabled");
         jobs = unique_ptr<JobsFeature>(new JobsFeature());
-        jobs->init(resourceManager, listener, config.config);
+        jobs->init(resourceManager->getConnection(), listener, config.config);
         features.push_back(jobs.get());
     }
     else

--- a/test/jobs/TestJobsFeature.cpp
+++ b/test/jobs/TestJobsFeature.cpp
@@ -3,13 +3,487 @@
 
 #include "../../source/Feature.h"
 #include "../../source/jobs/JobsFeature.h"
+#include <aws/iotjobs/IotJobsClient.h>
+#include <aws/iotjobs/NextJobExecutionChangedSubscriptionRequest.h>
+#include <aws/iotjobs/StartNextPendingJobExecutionRequest.h>
+#include <aws/iotjobs/StartNextPendingJobExecutionSubscriptionRequest.h>
+#include <aws/iotjobs/UpdateJobExecutionRequest.h>
+#include <aws/iotjobs/UpdateJobExecutionSubscriptionRequest.h>
+
+#include "aws/iotjobs/RejectedError.h"
+#include "aws/iotjobs/StartNextJobExecutionResponse.h"
+#include "aws/iotjobs/UpdateJobExecutionResponse.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace std;
+using namespace testing;
+using namespace Aws;
+using namespace Aws::Crt;
+using namespace Aws::Iotjobs;
+using namespace Aws::Iot::DeviceClient;
 using namespace Aws::Iot::DeviceClient::Jobs;
 
-TEST(JobsFeature, getName)
+PlainConfig getSimpleConfig()
 {
-    JobsFeature jobs;
-    ASSERT_STREQ(jobs.getName().c_str(), "Jobs");
+    constexpr char jsonString[] = R"(
+{
+    "endpoint": "endpoint value",
+    "cert": "/tmp/aws-iot-device-client-test-file",
+    "key": "/tmp/aws-iot-device-client-test-file",
+    "root-ca": "/tmp/aws-iot-device-client-test-file",
+    "thing-name": "thing-name value",
+    "logging": {
+        "level": "ERROR",
+        "type": "file",
+        "file": "./aws-iot-device-client.log"
+    },
+    "jobs": {
+        "enabled": true
+    }
+})";
+
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    return config;
+}
+
+JobExecutionData getSampleJobExecution(std::string jobId, int executionNumber)
+{
+    constexpr char jsonString[] = R"(
+{
+    "version": "1.0",
+    "jobId": "test-job-id",
+    "includeStdOut": "true",
+    "conditions": [{
+                    "key" : "operatingSystem",
+                    "value": ["ubuntu", "redhat"],
+                     "type": "stringEqual"
+                 },
+                 {
+                    "key" : "OS",
+                     "value": ["16.0"],
+                     "type": "stringEqual"
+    }],
+    "steps": [{
+            "action": {
+                "name": "downloadJobHandler",
+                "type": "runHandler",
+                "input": {
+                    "handler": "download-file.sh",
+                    "args": ["presignedUrl", "/tmp/aws-iot-device-client/"],
+                    "path": "path to handler"
+                },
+                "runAsUser": "user1",
+                "allowStdErr": 8,
+                "ignoreStepFailure": "true"
+            }
+        },
+        {
+            "action": {
+                "name": "installApplicationAndReboot",
+                "type": "runHandler",
+                "input": {
+                    "handler": "install-app.sh",
+                    "args": [
+                        "applicationName",
+                        "active"
+                    ],
+                    "path": "path to handler"
+                },
+                "runAsUser": "user1",
+                "allowStdErr": 8,
+                "ignoreStepFailure": "true"
+            }
+        },
+        {
+            "action": {
+                "name": "validateAppStatus",
+                "type": "runHandler",
+                "input": {
+                    "handler": "validate-app-status.sh",
+                    "args": [
+                        "applicationName",
+                        "active"
+                    ],
+                    "path": "path to handler"
+                },
+                "runAsUser": "user1",
+                "allowStdErr": 8,
+                "ignoreStepFailure": "true"
+            }
+        }
+    ],
+    "finalStep": {
+        "action": {
+            "name": "deleteDownloadedHandler",
+            "type": "runHandler",
+            "input": {
+                 "handler": "validate-app-status.sh",
+                 "args": [
+                    "applicationName",
+                    "active"
+                ],
+                "path": "path to handler"
+             },
+            "runAsUser": "user1",
+            "allowStdErr": 8,
+            "ignoreStepFailure": "true"
+        }
+    }
+})";
+
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    JobExecutionData jobExecutionData(jsonView);
+    jobExecutionData.JobDocument = Aws::Crt::Optional<JsonObject>(jsonObject);
+    jobExecutionData.JobId =
+        Aws::Crt::Optional<basic_string<char, char_traits<char>, StlAllocator<char>>>(jobId.c_str());
+    jobExecutionData.ExecutionNumber = Aws::Crt::Optional<int64_t>(executionNumber);
+
+    return jobExecutionData;
+}
+
+class MockJobsClient : public AbstractIotJobsClient
+{
+  public:
+    MOCK_METHOD(
+        void,
+        PublishStartNextPendingJobExecution,
+        (const StartNextPendingJobExecutionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnPublishComplete &onPubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        SubscribeToStartNextPendingJobExecutionAccepted,
+        (const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnSubscribeToStartNextPendingJobExecutionAcceptedResponse &handler,
+         const Iotjobs::OnSubscribeComplete &onSubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        SubscribeToStartNextPendingJobExecutionRejected,
+        (const Iotjobs::StartNextPendingJobExecutionSubscriptionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnSubscribeToStartNextPendingJobExecutionRejectedResponse &handler,
+         const Iotjobs::OnSubscribeComplete &onSubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        SubscribeToNextJobExecutionChangedEvents,
+        (const Iotjobs::NextJobExecutionChangedSubscriptionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnSubscribeToNextJobExecutionChangedEventsResponse &handler,
+         const Iotjobs::OnSubscribeComplete &onSubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        SubscribeToUpdateJobExecutionAccepted,
+        (const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnSubscribeToUpdateJobExecutionAcceptedResponse &handler,
+         const Iotjobs::OnSubscribeComplete &onSubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        SubscribeToUpdateJobExecutionRejected,
+        (const Iotjobs::UpdateJobExecutionSubscriptionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnSubscribeToUpdateJobExecutionRejectedResponse &handler,
+         const Iotjobs::OnSubscribeComplete &onSubAck),
+        (override));
+    MOCK_METHOD(
+        void,
+        PublishUpdateJobExecution,
+        (const Iotjobs::UpdateJobExecutionRequest &request,
+         Aws::Crt::Mqtt::QOS qos,
+         const Iotjobs::OnPublishComplete &onPubAck),
+        (override));
+};
+
+class MockNotifier : public Aws::Iot::DeviceClient::ClientBaseNotifier
+{
+  public:
+    MOCK_METHOD(
+        void,
+        onEvent,
+        (Aws::Iot::DeviceClient::Feature * feature, Aws::Iot::DeviceClient::ClientBaseEventNotification notification),
+        (override));
+    MOCK_METHOD(
+        void,
+        onError,
+        (Aws::Iot::DeviceClient::Feature * feature,
+         Aws::Iot::DeviceClient::ClientBaseErrorNotification notification,
+         const std::string &message),
+        (override));
+};
+
+class MockJobsFeature : public JobsFeature
+{
+  public:
+    MockJobsFeature() : JobsFeature() {}
+    void invokeRunJobs() { this->runJobs(); }
+    MOCK_METHOD(shared_ptr<AbstractIotJobsClient>, getJobsClient, (), (override));
+    MOCK_METHOD(
+        void,
+        publishUpdateJobExecutionStatusWithRetry,
+        (Aws::Iotjobs::JobExecutionData data,
+         JobsFeature::JobExecutionStatusInfo statusInfo,
+         (Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> statusDetails),
+         std::function<void(void)> onCompleteCallback),
+        (override));
+    MOCK_METHOD(void, executeJob, (const JobExecutionData &job, const PlainJobDocument &jobDocument), (override));
+};
+
+class TestJobsFeature : public ::testing::Test
+{
+  public:
+    void SetUp()
+    {
+        ThingName = Aws::Crt::String("thing-name value");
+        notifier = shared_ptr<MockNotifier>(new MockNotifier());
+        config = getSimpleConfig();
+        jobsMock = unique_ptr<MockJobsFeature>(new MockJobsFeature());
+        mockClient = shared_ptr<MockJobsClient>(new MockJobsClient());
+    }
+    Aws::Crt::String ThingName;
+    shared_ptr<MockNotifier> notifier;
+    PlainConfig config;
+    unique_ptr<JobsFeature> jobs;
+    unique_ptr<MockJobsFeature> jobsMock;
+    shared_ptr<MockJobsClient> mockClient;
+};
+
+MATCHER_P(ThingNameEq, ThingName, "Matcher ThingName for all Aws request Objects using Aws::Crt::String")
+{
+    return arg.ThingName.value() == ThingName;
+}
+
+MATCHER_P(StatusEq, status, "Matches JobExecutionStatusInfo status")
+{
+    return arg.status == status;
+}
+
+MATCHER_P(JobExecutionEq, job, "Matches JobExecutionData JobId & ExecutionNumber")
+{
+    return arg.JobId.value() == job.JobId.value() && arg.ExecutionNumber.value() == job.ExecutionNumber.value();
+}
+
+ACTION_P(Notify, promise)
+{
+    promise.set_value();
+}
+
+TEST_F(TestJobsFeature, GetName)
+{
+    /**
+     * Simple test for GetName
+     */
+    ASSERT_STREQ(jobsMock->getName().c_str(), "Jobs");
+}
+
+TEST_F(TestJobsFeature, Init)
+{
+    /**
+     * Test init Jobs with null MqttConnection, Mock notifier, and PlainConfig
+     */
+    ASSERT_EQ(0, jobsMock->init(std::shared_ptr<Mqtt::MqttConnection>(), notifier, config));
+}
+
+TEST_F(TestJobsFeature, RunJobsHappy)
+{
+    /**
+     * Inject a MockJobsClient into Jobs Feature and invoke RunJobs
+     * Verifies Subscription Requests to IotJobsClient and invokes SubAck Callback functions
+     * Invokes SubAck callbacks rather than elaborate argument matching
+     */
+    EXPECT_CALL(*jobsMock, getJobsClient()).Times(1).WillOnce(Return(mockClient));
+
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToNextJobExecutionChangedEvents(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(*mockClient, PublishStartNextPendingJobExecution(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<2>(0));
+
+    jobsMock->init(std::shared_ptr<Mqtt::MqttConnection>(), notifier, config);
+    jobsMock->invokeRunJobs();
+}
+
+TEST_F(TestJobsFeature, ExecuteJobHappy)
+{
+    /**
+     * Inject a MockJobsClient into Jobs Feature and invoke RunJobs
+     * Invokes the StartNextPendingJobExecution Handler with a Test JobExecution
+     * Verifies Subscription Requests to IotJobsClient and invokes SubAck Callback functions
+     * MockJobsFeature Mocks functions which start new threads so we simply verify their invocation here
+     */
+    const JobExecutionData job = getSampleJobExecution("job1", 1);
+    auto *response = new StartNextJobExecutionResponse();
+    response->Execution = Aws::Crt::Optional<JobExecutionData>(job);
+
+    EXPECT_CALL(*jobsMock, getJobsClient()).Times(1).WillOnce(Return(mockClient));
+
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(DoAll(InvokeArgument<3>(0), InvokeArgument<2>(response, 0)));
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToNextJobExecutionChangedEvents(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(*mockClient, PublishStartNextPendingJobExecution(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<2>(0));
+
+    EXPECT_CALL(
+        *jobsMock,
+        publishUpdateJobExecutionStatusWithRetry(
+            JobExecutionEq(job), StatusEq(Iotjobs::JobStatus::IN_PROGRESS), IsEmpty(), IsNull()))
+        .Times(1);
+    EXPECT_CALL(*jobsMock, executeJob(JobExecutionEq(job), _)).Times(1);
+
+    jobsMock->init(std::shared_ptr<Mqtt::MqttConnection>(), notifier, config);
+    jobsMock->invokeRunJobs();
+}
+
+TEST_F(TestJobsFeature, DuplicateJobNotification)
+{
+    /**
+     * Sends duplicate StartNextJobExecutionResponse to handler callback. Expect to only update and execute 1
+     * JobExecution
+     */
+    const JobExecutionData job = getSampleJobExecution("job1", 1);
+    auto *response = new StartNextJobExecutionResponse();
+    response->Execution = Aws::Crt::Optional<JobExecutionData>(job);
+
+    EXPECT_CALL(*jobsMock, getJobsClient()).Times(1).WillOnce(Return(mockClient));
+
+    // Invokes handler twice with same Job
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(DoAll(InvokeArgument<3>(0), InvokeArgument<2>(response, 0), InvokeArgument<2>(response, 0)));
+
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToNextJobExecutionChangedEvents(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(*mockClient, PublishStartNextPendingJobExecution(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<2>(0));
+
+    // Expects single update and execution
+    EXPECT_CALL(
+        *jobsMock,
+        publishUpdateJobExecutionStatusWithRetry(
+            JobExecutionEq(job), StatusEq(Iotjobs::JobStatus::IN_PROGRESS), IsEmpty(), IsNull()))
+        .Times(1);
+    EXPECT_CALL(*jobsMock, executeJob(JobExecutionEq(job), _)).Times(1);
+
+    jobsMock->init(std::shared_ptr<Mqtt::MqttConnection>(), notifier, config);
+    jobsMock->invokeRunJobs();
+}
+
+TEST_F(TestJobsFeature, InvalidJobDocument)
+{
+    /**
+     * Invoke handler callback with invalid JobDocument, expect JobExecution rejected
+     */
+    JobExecutionData job;
+    job.JobDocument = Aws::Crt::Optional<JsonObject>(JsonObject("{invalid}"));
+    job.JobId = Aws::Crt::Optional<basic_string<char, char_traits<char>, StlAllocator<char>>>("invalid-job");
+    job.ExecutionNumber = Aws::Crt::Optional<int64_t>(1);
+    auto *response = new StartNextJobExecutionResponse();
+    response->Execution = Aws::Crt::Optional<JobExecutionData>(job);
+
+    EXPECT_CALL(*jobsMock, getJobsClient()).Times(1).WillOnce(Return(mockClient));
+
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(DoAll(InvokeArgument<3>(0), InvokeArgument<2>(response, 0)));
+    EXPECT_CALL(
+        *mockClient,
+        SubscribeToStartNextPendingJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToNextJobExecutionChangedEvents(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(
+        *mockClient, SubscribeToUpdateJobExecutionRejected(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<3>(0));
+    EXPECT_CALL(*mockClient, PublishStartNextPendingJobExecution(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _))
+        .Times(1)
+        .WillOnce(InvokeArgument<2>(0));
+
+    EXPECT_CALL(
+        *jobsMock,
+        publishUpdateJobExecutionStatusWithRetry(JobExecutionEq(job), StatusEq(Iotjobs::JobStatus::REJECTED), _, _))
+        .Times(1);
+
+    jobsMock->init(std::shared_ptr<Mqtt::MqttConnection>(), notifier, config);
+    jobsMock->invokeRunJobs();
 }

--- a/test/jobs/TestJobsFeature.cpp
+++ b/test/jobs/TestJobsFeature.cpp
@@ -402,7 +402,10 @@ TEST_F(TestJobsFeature, DuplicateJobNotification)
         *mockClient,
         SubscribeToStartNextPendingJobExecutionAccepted(ThingNameEq(ThingName), AWS_MQTT_QOS_AT_LEAST_ONCE, _, _))
         .Times(1)
-        .WillOnce(DoAll(InvokeArgument<3>(0), InvokeArgument<2>(startNextJobExecutionResponse, 0), InvokeArgument<2>(startNextJobExecutionResponse, 0)));
+        .WillOnce(DoAll(
+            InvokeArgument<3>(0),
+            InvokeArgument<2>(startNextJobExecutionResponse, 0),
+            InvokeArgument<2>(startNextJobExecutionResponse, 0)));
 
     EXPECT_CALL(
         *mockClient,


### PR DESCRIPTION
Motivation
JobsFeature did not have unit tests. Some refactoring was required for testability.

Modifications
Change summary
Created an interface and wrapper for IotJobsClient so it could be mocked for testing JobsFeature.
Refactored jobs by splitting off methods which create new threads for mocking. Added a method to allow injecting a mock IotJobsClient.
Added unit tests.
Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

Testing
Unit tests pass and ran Jobs feature locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.