### PR TITLE
Disable device defender by default

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,7 +28,9 @@ field by running `aws iot describe-endpoint` on the CLI.
 
 `thing-name` *or* `--thing-name`: This is the name for your thing. It should be unique across your regional AWS account. Thing Name is also used as client id while connecting to the IoT core.
 
-**Note:** If the `root-ca` *or* `--root-ca` file path is missing, Device Client will look for the ROOT-CA file stored on the IoT device. `root-ca` is no longer a mandatory field but we would recommend users to pass in the valid path to `root-ca` file via JSON or CLI config.   
+**Note:** If the `root-ca` *or* `--root-ca` file path is missing, Device Client will look for the ROOT-CA file stored on the IoT device. `root-ca` is no longer a mandatory field but we would recommend users to pass in the valid path to `root-ca` file via JSON or CLI config.
+
+**Note:** With a minimum configuration the Device Client by default will run with Jobs and SecureTunneling features enabled only.
 
 **Next**: [File and Directory Permission Requirements](PERMISSIONS.md)
 

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -203,7 +203,7 @@ namespace Aws
                     static constexpr char JSON_KEY_ENABLED[] = "enabled";
                     static constexpr char JSON_KEY_INTERVAL[] = "interval";
 
-                    bool enabled{true};
+                    bool enabled{false};
                     int interval{300};
                 };
                 DeviceDefender deviceDefender;

--- a/source/jobs/README.md
+++ b/source/jobs/README.md
@@ -410,7 +410,7 @@ Example:
 cmake ../ -DEXCLUDE_JOBS=ON
 ```
 ### Jobs Feature Configuration Options
-`enabled`: Whether or not the jobs feature is enabled (True/False).
+`enabled`: Whether or not the Jobs feature is enabled (True/False). If not specified, Jobs feature is enabled by default.
  
 `handler-directory`: A path to a directory containing scripts or executables that the Jobs feature should look in
 when receiving an incoming job. If there is a script or executable in the directory that matches the name of the

--- a/source/tunneling/README.md
+++ b/source/tunneling/README.md
@@ -20,7 +20,7 @@ Without the Device Client, if you wanted secure privileged access to a device by
 
 You can enable or disable the Secure Tunneling feature by a CLI argument or in the configuration file.
 
-`enabled`: Whether or not the Secure Tunneling feature is enabled (True/False).
+`enabled`: Whether or not the Secure Tunneling feature is enabled (True/False). If not specified, Secure Tunneling feature is enabled by default.
 
 #### Configuring the Secure Tunneling feature via the command line
 ```

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -71,7 +71,6 @@ class ConfigTestFixture : public ::testing::Test
     {
         ASSERT_TRUE(config.jobs.enabled);
         ASSERT_TRUE(config.tunneling.enabled);
-        ASSERT_TRUE(config.deviceDefender.enabled);
     }
 };
 
@@ -217,6 +216,10 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumConfig)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -233,6 +236,10 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumCli)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -263,6 +270,10 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaConfig)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -290,6 +301,10 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaCli)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -524,6 +539,10 @@ TEST_F(ConfigTestFixture, emptyRootCaPathConfig)
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -550,6 +569,10 @@ TEST_F(ConfigTestFixture, InvalidRootCaPathConfigCli)
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 
@@ -580,6 +603,10 @@ TEST_F(ConfigTestFixture, InvalidRootCaPathConfig)
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
     ASSERT_FALSE(config.fleetProvisioning.enabled);
+    ASSERT_FALSE(config.deviceDefender.enabled);
+    ASSERT_FALSE(config.sampleShadow.enabled);
+    ASSERT_FALSE(config.sensorPublish.enabled);
+    ASSERT_FALSE(config.pubSub.enabled);
     DefaultFeaturesEnabled(config);
 }
 

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -67,10 +67,15 @@ class ConfigTestFixture : public ::testing::Test
         std::remove(addrPathInvalid.c_str());
     }
 
-    static void DefaultFeaturesEnabled(const PlainConfig &config)
+    static void AssertDefaultFeaturesEnabled(const PlainConfig &config)
     {
         ASSERT_TRUE(config.jobs.enabled);
         ASSERT_TRUE(config.tunneling.enabled);
+        ASSERT_FALSE(config.fleetProvisioning.enabled);
+        ASSERT_FALSE(config.deviceDefender.enabled);
+        ASSERT_FALSE(config.sampleShadow.enabled);
+        ASSERT_FALSE(config.sensorPublish.enabled);
+        ASSERT_FALSE(config.pubSub.enabled);
     }
 };
 
@@ -215,12 +220,7 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumConfig)
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 TEST_F(ConfigTestFixture, HappyCaseMinimumCli)
@@ -235,12 +235,7 @@ TEST_F(ConfigTestFixture, HappyCaseMinimumCli)
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 /**
@@ -269,12 +264,7 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaConfig)
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 /**
@@ -300,12 +290,7 @@ TEST_F(ConfigTestFixture, HappyCaseExplicitRootCaCli)
     ASSERT_STREQ(filePath.c_str(), config.cert->c_str());
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 /**
@@ -538,12 +523,7 @@ TEST_F(ConfigTestFixture, emptyRootCaPathConfig)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 /**
@@ -568,12 +548,7 @@ TEST_F(ConfigTestFixture, InvalidRootCaPathConfigCli)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 /**
@@ -602,12 +577,7 @@ TEST_F(ConfigTestFixture, InvalidRootCaPathConfig)
     ASSERT_STREQ(filePath.c_str(), config.key->c_str());
     ASSERT_FALSE(config.rootCa.has_value());
     ASSERT_STREQ("thing-name value", config.thingName->c_str());
-    ASSERT_FALSE(config.fleetProvisioning.enabled);
-    ASSERT_FALSE(config.deviceDefender.enabled);
-    ASSERT_FALSE(config.sampleShadow.enabled);
-    ASSERT_FALSE(config.sensorPublish.enabled);
-    ASSERT_FALSE(config.pubSub.enabled);
-    DefaultFeaturesEnabled(config);
+    AssertDefaultFeaturesEnabled(config);
 }
 
 TEST_F(ConfigTestFixture, MissingSomeSettings)


### PR DESCRIPTION
### Motivation
Disabling Device Defender by default so that customers are not surprised by this feature being enabled without explicitly enabling it.


### Modifications
#### Change summary
Make DD default disabled. Update Config tests to assert DD is disabled with minimum config. Add to documentation.

### Testing
Unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
