### PR TITLE
Update SDK with secure tunneling null websocket fix

### DIFF
--- a/.github/docker-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/amazonlinux/Dockerfile
@@ -84,7 +84,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
+    && git checkout 975dcefbd422604b939ff916751bf7b11ac05d14 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/ubi8/Dockerfile
+++ b/.github/docker-images/ubi8/Dockerfile
@@ -55,7 +55,7 @@ RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
 # Install softhsm v2.3.0 from source
 ###############################################################################
 
-WORKDIR /tmp 
+WORKDIR /tmp
 RUN wget https://dist.opendnssec.org/source/softhsm-2.3.0.tar.gz \
     && tar -xzf softhsm-2.3.0.tar.gz \
     && cd softhsm-2.3.0 \
@@ -96,7 +96,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
+    && git checkout 975dcefbd422604b939ff916751bf7b11ac05d14 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout 3223ce81919bff882014bcc57fd5348f758397bc \
+    && git checkout 975dcefbd422604b939ff916751bf7b11ac05d14 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/CMakeLists.txt.awssdk
+++ b/CMakeLists.txt.awssdk
@@ -5,7 +5,7 @@ project(aws-iot-device-sdk-cpp-v2-download NONE)
 include(ExternalProject)
 ExternalProject_Add(aws-iot-device-sdk-cpp-v2
         GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
-        GIT_TAG                 3223ce81919bff882014bcc57fd5348f758397bc
+        GIT_TAG                 975dcefbd422604b939ff916751bf7b11ac05d14
         SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
         CONFIGURE_COMMAND       ""


### PR DESCRIPTION

### Motivation
* Fix segmentation fault when closing secure tunnel with null websocket


### Modifications
#### Change summary
* Bump SDK to pick up secure tunnel fix in aws-c-iot [b50828c](https://github.com/awslabs/aws-c-iot/commit/b50828cf19821a7c21f3b8b4df352529b3fc0c39)

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
* Users who enable secure tunneling and shutdown the device client before the websocket connection is established would observe a segmentation fault.  That behavior is fixed as part of this commit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
