### PR TITLE
Adds tests for JobEngine and fix stdout/stderr bug in JobsFeature

### DIFF
--- a/source/jobs/JobsFeature.h
+++ b/source/jobs/JobsFeature.h
@@ -47,21 +47,23 @@ namespace Aws
                     /**
                      * \brief Wrapper struct to aggregate JobEngine output for updating a job execution status
                      */
+
                     struct JobExecutionStatusInfo
                     {
-                        Iotjobs::JobStatus status;
+                        Aws::Iotjobs::JobStatus status;
                         std::string reason;
-                        std::string output;
+                        std::string stdoutput;
+                        std::string stderror;
 
+                        explicit JobExecutionStatusInfo(Aws::Iotjobs::JobStatus status) : status(status) {}
                         JobExecutionStatusInfo(
-                            Iotjobs::JobStatus status,
+                            Aws::Iotjobs::JobStatus status,
                             const std::string &reason,
-                            const std::string &output)
-                            : status(status), reason(reason), output(output)
+                            const std::string &stdoutput,
+                            const std::string &stderror)
+                            : status(status), reason(reason), stdoutput(stdoutput), stderror(stderror)
                         {
                         }
-
-                        explicit JobExecutionStatusInfo(Iotjobs::JobStatus status) : status(status) {}
                     };
 
                   private:
@@ -74,12 +76,13 @@ namespace Aws
                      * \brief The default directory that the Jobs feature will use to find executables matching
                      * an incoming job document's operation attribute
                      */
+                    const std::string DEFAULT_JOBS_HANDLER_DIR = "~/.aws-iot-device-client/jobs/";
+
                     /**
                      * \brief A limit enforced by the AWS IoT Jobs API on the maximum number of characters allowed
                      * to be provided in a StatusDetail entry when calling the UpdateJobExecution API
                      */
                     const size_t MAX_STATUS_DETAIL_LENGTH = 1024;
-                    const std::string DEFAULT_JOBS_HANDLER_DIR = "~/.aws-iot-device-client/jobs/";
 
                     /**
                      * \brief Whether the DeviceClient base has requested this feature to stop

--- a/test/jobs/TestJobDocument.cpp
+++ b/test/jobs/TestJobDocument.cpp
@@ -240,7 +240,7 @@ TEST(JobDocument, SampleJobDocument)
     ASSERT_TRUE(jobDocument.finalStep->ignoreStepFailure);
 }
 
-TEST(JobDocuemnt, MissingRequiredFields)
+TEST(JobDocument, MissingRequiredFields)
 {
     constexpr char jsonString[] = R"(
 {
@@ -333,7 +333,7 @@ TEST(JobDocuemnt, MissingRequiredFields)
     ASSERT_FALSE(jobDocument.Validate());
 }
 
-TEST(JobDocuemnt, MinimumJobDocument)
+TEST(JobDocument, MinimumJobDocument)
 {
     constexpr char jsonString[] = R"(
 {
@@ -377,7 +377,7 @@ TEST(JobDocuemnt, MinimumJobDocument)
     ASSERT_TRUE(jobDocument.Validate());
 }
 
-TEST(JobDocuemnt, MissingRequiredFieldsValue)
+TEST(JobDocument, MissingRequiredFieldsValue)
 {
     constexpr char jsonString[] = R"(
 {

--- a/test/jobs/TestJobEngine.cpp
+++ b/test/jobs/TestJobEngine.cpp
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../source/jobs/JobEngine.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <fstream>
+
+using namespace std;
+using namespace Aws;
+using namespace Aws::Iot;
+using namespace Aws::Iot::DeviceClient;
+using namespace Aws::Iot::DeviceClient::Util;
+using namespace Aws::Iot::DeviceClient::Jobs;
+
+PlainJobDocument::JobAction createJobAction(
+    string name,
+    string type,
+    string handler,
+    std::vector<std::string> args,
+    string path,
+    bool ignoreStepFailure)
+{
+    PlainJobDocument::JobAction::ActionInput input;
+    input.handler = handler;
+    input.args = args;
+    input.path = path;
+
+    PlainJobDocument::JobAction action;
+    action.name = name;
+    action.type = type;
+    action.ignoreStepFailure = ignoreStepFailure;
+    action.input = input;
+
+    return action;
+}
+
+PlainJobDocument createTestJobDocument(vector<PlainJobDocument::JobAction> steps, bool includeStdOut)
+{
+    PlainJobDocument jobDocument;
+    jobDocument.version = "1.0";
+    jobDocument.includeStdOut = includeStdOut;
+    jobDocument.steps = steps;
+
+    return jobDocument;
+}
+
+PlainJobDocument createTestJobDocument(
+    vector<PlainJobDocument::JobAction> steps,
+    PlainJobDocument::JobAction finalStep,
+    bool includeStdOut)
+{
+    PlainJobDocument jobDocument = createTestJobDocument(steps, includeStdOut);
+    jobDocument.finalStep = finalStep;
+    return jobDocument;
+}
+
+const string testHandlerDirectoryPath = "/tmp/device-client-tests";
+const string successHandlerPath = testHandlerDirectoryPath + "/successHandler";
+const string errorHandlerPath = testHandlerDirectoryPath + "/errorHandler";
+
+const string testStdout = "This is test stdout";
+const string testStderr = "This is test stderr";
+const string successHandlerScript = "echo \"" + testStdout + "\"";
+const string errorHandlerScript = "1>&2 echo \"" + testStderr + "\"; exit 1";
+
+class TestJobEngine : public testing::Test
+{
+  public:
+    void SetUp() override
+    {
+        Util::FileUtils::CreateDirectoryWithPermissions(testHandlerDirectoryPath.c_str(), 0700);
+
+        ofstream successHandler(successHandlerPath, std::fstream::app);
+        chmod(successHandlerPath.c_str(), 0700);
+        successHandler << successHandlerScript << endl;
+
+        ofstream errorHandler(errorHandlerPath, std::fstream::app);
+        chmod(errorHandlerPath.c_str(), 0700);
+        errorHandler << errorHandlerScript << endl;
+    }
+
+    void TearDown() override
+    {
+        std::remove(successHandlerPath.c_str());
+        std::remove(errorHandlerPath.c_str());
+        std::remove(testHandlerDirectoryPath.c_str());
+    }
+};
+
+TEST_F(TestJobEngine, ExecuteStepsHappy)
+{
+    vector<PlainJobDocument::JobAction> steps;
+    vector<std::string> args;
+    steps.push_back(
+        createJobAction("testAction", "runHandler", "successHandler", args, "/tmp/device-client-tests/", false));
+    PlainJobDocument jobDocument = createTestJobDocument(steps, true);
+    JobEngine jobEngine;
+
+    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
+    ASSERT_EQ(executionStatus, 0);
+    ASSERT_STREQ(jobEngine.getStdOut().c_str(), std::string(testStdout + "\n").c_str());
+}
+
+TEST_F(TestJobEngine, ExecuteSucceedThenFail)
+{
+    vector<PlainJobDocument::JobAction> steps;
+    vector<std::string> args;
+    steps.push_back(
+        createJobAction("testAction", "runHandler", "successHandler", args, "/tmp/device-client-tests/", false));
+    PlainJobDocument::JobAction finalStep =
+        createJobAction("testAction", "runHandler", "errorHandler", args, "/tmp/device-client-tests/", false);
+    PlainJobDocument jobDocument = createTestJobDocument(steps, finalStep, true);
+    JobEngine jobEngine;
+
+    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
+    ASSERT_NE(executionStatus, 0);
+    ASSERT_STREQ(jobEngine.getStdOut().c_str(), std::string(testStdout + "\n").c_str());
+    ASSERT_STREQ(jobEngine.getStdErr().c_str(), std::string(testStderr + "\n").c_str());
+}
+
+TEST_F(TestJobEngine, ExecuteFinalStepOnly)
+{
+    vector<PlainJobDocument::JobAction> steps;
+    vector<std::string> args;
+    PlainJobDocument::JobAction finalStep =
+        createJobAction("testAction", "runHandler", "successHandler", args, "/tmp/device-client-tests/", false);
+    PlainJobDocument jobDocument = createTestJobDocument(steps, finalStep, true);
+    JobEngine jobEngine;
+
+    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
+    ASSERT_EQ(executionStatus, 0);
+    ASSERT_STREQ(jobEngine.getStdOut().c_str(), std::string(testStdout + "\n").c_str());
+}
+
+TEST_F(TestJobEngine, ExecuteStepsError)
+{
+    vector<PlainJobDocument::JobAction> steps;
+    vector<std::string> args;
+    steps.push_back(
+        createJobAction("testAction", "runHandler", "errorHandler", args, "/tmp/device-client-tests/", false));
+    PlainJobDocument jobDocument = createTestJobDocument(steps, true);
+    JobEngine jobEngine;
+
+    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
+    ASSERT_NE(executionStatus, 0);
+    ASSERT_STREQ(jobEngine.getStdErr().c_str(), std::string(testStderr + "\n").c_str());
+}
+
+TEST_F(TestJobEngine, ExecuteNoSteps)
+{
+    vector<PlainJobDocument::JobAction> steps;
+    vector<std::string> args;
+    PlainJobDocument jobDocument = createTestJobDocument(steps, true);
+    JobEngine jobEngine;
+
+    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
+    ASSERT_EQ(executionStatus, 0);
+    ASSERT_TRUE(jobEngine.getStdOut().length() == 0);
+    ASSERT_TRUE(jobEngine.getStdErr().length() == 0);
+}


### PR DESCRIPTION
### Motivation
Need unit tests for JobEngine.
While writing tests I realized a previous change I had made for modifying JobExecutionStatusInfo needed to be fixed. We previously never included both stderr and stdout in the status details but we should have because steps can fail without the job failing.

Still needs more tests but I believe this is a big improvement over having no tests.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
