### PR TITLE
Issue 283

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -343,9 +343,7 @@ if [ "$INSTALL_SERVICE" = "y" ]; then
   done
 
   ### Get DeviceClient Service File Location ###
-  
-  
-  =false
+  FOUND_SERVICE_FILE=false
   SERVICE_FILE_DEFAULT="./setup/aws-iot-device-client.service"
   while [ "$FOUND_SERVICE_FILE" != true ]; do
     printf ${PMPT} "Enter the complete directory path for the aws-iot-device-client service file. (Empty for default: ${SERVICE_FILE_DEFAULT})"

--- a/setup.sh
+++ b/setup.sh
@@ -343,7 +343,9 @@ if [ "$INSTALL_SERVICE" = "y" ]; then
   done
 
   ### Get DeviceClient Service File Location ###
-  FOUND_SERVICE_FILE=false
+  
+  
+  =false
   SERVICE_FILE_DEFAULT="./setup/aws-iot-device-client.service"
   while [ "$FOUND_SERVICE_FILE" != true ]; do
     printf ${PMPT} "Enter the complete directory path for the aws-iot-device-client service file. (Empty for default: ${SERVICE_FILE_DEFAULT})"
@@ -374,6 +376,7 @@ if [ "$INSTALL_SERVICE" = "y" ]; then
   printf ${PMPT} "Installing AWS IoT Device Client..."
   if command -v "systemctl" &>/dev/null; then
     systemctl stop aws-iot-device-client.service || true
+    sed -i "s#/etc/.aws-iot-device-client/aws-iot-device-client.conf#$CONF_OUTPUT_PATH#g" $SERVICE_FILE
     cp "$SERVICE_FILE" /etc/systemd/system/aws-iot-device-client.service
     if [ "$SERVICE_DEBUG" = "y" ]; then
       echo "$DEBUG_SCRIPT" | tee /sbin/aws-iot-device-client >/dev/null

--- a/setup/aws-iot-device-client.service
+++ b/setup/aws-iot-device-client.service
@@ -4,7 +4,8 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/sbin/aws-iot-device-client --config-file CONF_FILE_PATH
+Environment="CONF_PATH=/etc/.aws-iot-device-client/aws-iot-device-client.conf"
+ExecStart=/sbin/aws-iot-device-client --config-file $CONF_PATH
 
 [Install]
 WantedBy=multi-user.target

--- a/setup/aws-iot-device-client.service
+++ b/setup/aws-iot-device-client.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/sbin/aws-iot-device-client --config-file /etc/.aws-iot-device-client/aws-iot-device-client.conf
+ExecStart=/sbin/aws-iot-device-client --config-file CONF_FILE_PATH
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Motivation
- Improves the setup.sh file and systemd service file by parameterizing the config file path
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/283


### Modifications
#### Change summary
A simple find and replace substitution in the setup.sh file that replaces the default path with the parameterized one.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.** 
Yes 
 **Please list your testing steps and test results.** 
1. Create a non-root sudo user in Ubuntu.
2. Login as the said user.
3. Install the client using the modified the setup.sh file
4. Execute it locally on machine.
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
