### PR TITLE
Separate sensor publish socket file and directory permissions

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -36,6 +36,7 @@ Directory Storing CSR File  | 700               | **Yes**
 Directory Storing Log File  | 745               | **Yes**
 Directory Storing Config Files | 745               | **Recommended**
 Directory Storing PubSub File  | 745               | **Yes**
+Directory Storing Sensor Publish Pathname Socket | 700               | **Yes**
 Directory Storing PKCS11 Library File  | 700               | **Yes**
 
 *Note: It is worth noting here that files are directories storing these files created by AWS IoT Device Client will have the above mentioned permissions set by default*

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1829,7 +1829,7 @@ bool PlainConfig::SensorPublish::Validate() const
             // If the path does not point to an existing file,
             // then check the parent directory exists and has required permissions.
             auto addrParentDir = FileUtils::ExtractParentDirectory(setting.addr.value());
-            if (!FileUtils::ValidateFilePermissions(addrParentDir, Permissions::SENSOR_PUBLISH_ADDR_FILE))
+            if (!FileUtils::ValidateFilePermissions(addrParentDir, Permissions::SENSOR_PUBLISH_ADDR_DIR))
             {
                 setting.enabled = false;
             }

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -58,6 +58,7 @@ namespace Aws
                 static constexpr int PUB_SUB_FILES = 600;
                 static constexpr int SAMPLE_SHADOW_FILES = 600;
                 static constexpr int SENSOR_PUBLISH_ADDR_FILE = 660;
+                static constexpr int SENSOR_PUBLISH_ADDR_DIR = 700;
                 static constexpr int PKCS11_LIB_FILE = 640;
             };
 

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -50,7 +50,7 @@ class ConfigTestFixture : public ::testing::Test
 
         // Ensure invalid-file does not exist
         std::remove(invalidFilePath.c_str());
-        mode_t validPerms = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+        mode_t validPerms = S_IRUSR | S_IWUSR | S_IXUSR;
         FileUtils::CreateDirectoryWithPermissions(addrPathValid.c_str(), validPerms);
 
         mode_t invalidPerms = validPerms | S_IRWXO;


### PR DESCRIPTION
### Motivation
- The sensor publish feature enforces the same permission check on unix domain socket file and directory (`rw-rw----`).
- Process cannot open and read from unix domain socket directory with permissions (`rw-rw----`).


### Modifications
#### Change summary
- Enforces separate permission check on unix domain socket file (`rw-rw----`) and directory (`rwx------`) .

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
- Updated unit test to reflect changes.
- Local functional test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
