### PR TITLE
Placeholder input validation

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -576,7 +576,7 @@ bool PlainConfig::LogConfig::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_LOG_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             deviceClientLogFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -616,7 +616,7 @@ bool PlainConfig::LogConfig::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_SDK_LOG_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             sdkLogFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -93,7 +93,7 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_CERT;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             cert = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -106,7 +106,7 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_KEY;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             key = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -119,7 +119,7 @@ bool PlainConfig::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_ROOT_CA;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             auto path = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
             if (FileUtils::FileExists(path))
@@ -354,20 +354,12 @@ bool PlainConfig::Validate() const
         LOGM_ERROR(Config::TAG, "*** %s: Certificate is missing ***", DeviceClient::DC_FATAL_ERROR);
         return false;
     }
-    else if (!FileUtils::IsValidFilePath(cert->c_str()))
-    {
-        return false;
-    }
 
     if (!secureElement.enabled)
     {
         if (!key.has_value() || key->empty())
         {
             LOGM_ERROR(Config::TAG, "*** %s: Private Key is missing ***", DeviceClient::DC_FATAL_ERROR);
-            return false;
-        }
-        else if (!FileUtils::IsValidFilePath(key->c_str()))
-        {
             return false;
         }
     }
@@ -716,7 +708,7 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     }
 
     jsonKey = JSON_KEY_HANDLER_DIR;
-    if (json.ValueExists(jsonKey) && !json.GetString(jsonKey).empty())
+    if (json.ValueExists(jsonKey) && !json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
     {
         handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
     }
@@ -976,7 +968,7 @@ bool PlainConfig::FleetProvisioning::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_CSR_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             csrFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -988,7 +980,7 @@ bool PlainConfig::FleetProvisioning::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_KEY_DEVICE_KEY;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             deviceKey = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1047,22 +1039,6 @@ bool PlainConfig::FleetProvisioning::Validate() const
         return false;
     }
 
-    if (csrFile.has_value() && !csrFile->empty())
-    {
-        if (!FileUtils::IsValidFilePath(csrFile->c_str()))
-        {
-            return false;
-        }
-    }
-
-    if (deviceKey.has_value() && !deviceKey->empty())
-    {
-        if (!FileUtils::IsValidFilePath(deviceKey->c_str()))
-        {
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -1083,7 +1059,7 @@ bool PlainConfig::FleetProvisioningRuntimeConfig::LoadFromJson(const Crt::JsonVi
     jsonKey = JSON_KEY_CERT;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             cert = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1096,7 +1072,7 @@ bool PlainConfig::FleetProvisioningRuntimeConfig::LoadFromJson(const Crt::JsonVi
     jsonKey = JSON_KEY_KEY;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             key = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1169,7 +1145,7 @@ bool PlainConfig::PubSub::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_PUB_SUB_PUBLISH_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             publishFile = json.GetString(jsonKey).c_str();
         }
@@ -1195,7 +1171,7 @@ bool PlainConfig::PubSub::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_PUB_SUB_SUBSCRIBE_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             subscribeFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1239,24 +1215,6 @@ bool PlainConfig::PubSub::Validate() const
     {
         return true;
     }
-    if (!publishTopic.has_value() || publishTopic->empty())
-    {
-        LOGM_ERROR(
-            Config::TAG,
-            "*** %s: Publish Topic field must be specified if Pub-Sub sample feature is enabled ***",
-            DeviceClient::DC_FATAL_ERROR);
-        return false;
-    }
-
-    if (!subscribeTopic.has_value() || subscribeTopic->empty())
-    {
-        LOGM_ERROR(
-            Config::TAG,
-            "*** %s: Subscribe Topic field must be specified if Pub-Sub sample feature is enabled ***",
-            DeviceClient::DC_FATAL_ERROR);
-        return false;
-    }
-
     return true;
 }
 
@@ -1318,7 +1276,7 @@ bool PlainConfig::SampleShadow::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_SAMPLE_SHADOW_INPUT_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             shadowInputFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1334,7 +1292,7 @@ bool PlainConfig::SampleShadow::LoadFromJson(const Crt::JsonView &json)
     jsonKey = JSON_SAMPLE_SHADOW_OUTPUT_FILE;
     if (json.ValueExists(jsonKey))
     {
-        if (!json.GetString(jsonKey).empty())
+        if (!json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
         {
             shadowOutputFile = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
         }
@@ -1393,14 +1351,7 @@ bool PlainConfig::SampleShadow::Validate() const
 
     if (shadowInputFile.has_value() && !shadowInputFile->empty())
     {
-        if (FileUtils::IsValidFilePath(shadowInputFile->c_str()))
-        {
-            if (!FileUtils::ValidateFilePermissions(shadowInputFile.value(), Permissions::SAMPLE_SHADOW_FILES, true))
-            {
-                return false;
-            }
-        }
-        else
+        if (!FileUtils::ValidateFilePermissions(shadowInputFile.value(), Permissions::SAMPLE_SHADOW_FILES, true))
         {
             return false;
         }
@@ -1408,14 +1359,7 @@ bool PlainConfig::SampleShadow::Validate() const
 
     if (shadowOutputFile.has_value() && !shadowOutputFile->empty())
     {
-        if (FileUtils::IsValidFilePath(shadowOutputFile->c_str()))
-        {
-            if (!FileUtils::ValidateFilePermissions(shadowOutputFile.value(), Permissions::SAMPLE_SHADOW_FILES, true))
-            {
-                return false;
-            }
-        }
-        else
+        if (!FileUtils::ValidateFilePermissions(shadowOutputFile.value(), Permissions::SAMPLE_SHADOW_FILES, true))
         {
             return false;
         }

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -708,7 +708,8 @@ bool PlainConfig::Jobs::LoadFromJson(const Crt::JsonView &json)
     }
 
     jsonKey = JSON_KEY_HANDLER_DIR;
-    if (json.ValueExists(jsonKey) && !json.GetString(jsonKey).empty() && FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
+    if (json.ValueExists(jsonKey) && !json.GetString(jsonKey).empty() &&
+        FileUtils::IsValidFilePath(json.GetString(jsonKey).c_str()))
     {
         handlerDir = FileUtils::ExtractExpandedPath(json.GetString(jsonKey).c_str());
     }

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -224,6 +224,72 @@ TEST_F(ConfigTestFixture, AllFeaturesEnabled)
     ASSERT_STREQ(
         "token-label", secureElement.View().GetString(config.secureElement.JSON_SECURE_ELEMENT_TOKEN_LABEL).c_str());
 }
+/**
+ * tests if fields requiring ExtractExpandedPath() are passed in with bad characters
+ */
+TEST_F(ConfigTestFixture, PlaceholderInput)
+{
+    constexpr char jsonString[] = R"(
+{
+    "endpoint": "<replace_with_endpoint_value>",
+    "cert": "<replace_with_certificate_file_path>",
+    "key": "<replace_with_private_key_file_path>",
+    "thing-name": "<replace_with_thing_name/replace_with_client_id>",
+    "logging": {
+        "level": "debug",
+        "type": "file",
+        "file": "./aws-iot-device-client.log"
+    },
+    "jobs": {
+        "enabled": true
+    },
+    "tunneling": {
+        "enabled": true
+    },
+    "device-defender": {
+        "enabled": true,
+        "interval": 300
+    },
+    "fleet-provisioning": {
+        "enabled": true,
+        "template-name": "template-name",
+        "csr-file": "<replace_with_csr_file_path>",
+        "device-key": "<replace_with_device_private_key_file_path>",
+        "template-parameters": "{\"SerialNumber\": \"Device-SN\"}"
+    },
+    "samples": {
+		"pub-sub": {
+			"enabled": true,
+			"publish-topic": "publish_topic",
+			"subscribe-topic": "subscribe_topic"
+		}
+	},
+    "config-shadow": {
+        "enabled": true
+      },
+    "sample-shadow": {
+        "enabled": true,
+        "shadow-name": "shadow-name",
+        "shadow-input-file": "<replace_with_shadow_input_file_path>",
+        "shadow-output-file": "<replace_with_shadow_output_file_path>"
+      },
+    "secure-element": {
+        "enabled": true,
+        "pkcs11-lib": "/tmp/aws-iot-device-client-test-file",
+        "secure-element-pin": "0000",
+        "secure-element-key-label": "key-label",
+        "secure-element-slot-id": 1111,
+        "secure-element-token-label": "token-label"
+      }
+})";
+    JsonObject jsonObject(jsonString);
+    JsonView jsonView = jsonObject.View();
+
+    PlainConfig config;
+    config.LoadFromJson(jsonView);
+
+    ASSERT_FALSE(config.Validate());
+}
 
 TEST_F(ConfigTestFixture, HappyCaseMinimumConfig)
 {

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -127,6 +127,7 @@ TEST_F(SharedResourceManagerTest, badPermissionsKey)
     ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
+#if !defined(DISABLE_MQTT)
 TEST_F(SharedResourceManagerTest, invalidCert)
 {
 
@@ -144,6 +145,27 @@ TEST_F(SharedResourceManagerTest, invalidKey)
 
     ASSERT_FALSE(config.Validate());
 }
+#endif
+
+#if defined(DISABLE_MQTT)
+TEST_F(SharedResourceManagerTest, invalidCertForST)
+{
+
+    PlainConfig config;
+    config = getConfig(invalidCertFilePath, keyFilePath);
+
+    ASSERT_TRUE(config.Validate());
+}
+
+TEST_F(SharedResourceManagerTest, invalidKeyForST)
+{
+
+    PlainConfig config;
+    config = getConfig(invalidCertFilePath, keyFilePath);
+
+    ASSERT_TRUE(config.Validate());
+}
+#endif
 
 TEST_F(SharedResourceManagerTest, badPermissionsDirectory)
 {

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -33,7 +33,7 @@ static PlainConfig getConfig(string certPath, string keyPath)
 
     std::string jsonString = "{\"endpoint\": \"endpoint value\",\n"
                              "\"cert\": \"" +
-                             certPath + "\",\n\"key\": \"" + keyPath + "\"}";
+                             certPath + "\",\n\"key\": \"" + keyPath + "\",\n\"thing-name\": \"thing-name value\"}";
 
     JsonObject jsonObject(jsonString.c_str());
     JsonView jsonView = jsonObject.View();
@@ -103,6 +103,7 @@ TEST_F(SharedResourceManagerTest, locateCredentialsHappy)
     PlainConfig config;
     config = getConfig(certFilePath, keyFilePath);
 
+    ASSERT_TRUE(config.Validate());
     ASSERT_TRUE(manager.locateCredentialsWrapper(config));
 }
 
@@ -112,6 +113,7 @@ TEST_F(SharedResourceManagerTest, badPermissionsCert)
     PlainConfig config;
     config = getConfig(badPermissionsCertFilePath, keyFilePath);
 
+    ASSERT_TRUE(config.Validate());
     ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
@@ -121,6 +123,7 @@ TEST_F(SharedResourceManagerTest, badPermissionsKey)
     PlainConfig config;
     config = getConfig(certFilePath, badPermissionsKeyFilePath);
 
+    ASSERT_TRUE(config.Validate());
     ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }
 
@@ -130,7 +133,7 @@ TEST_F(SharedResourceManagerTest, invalidCert)
     PlainConfig config;
     config = getConfig(invalidCertFilePath, keyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
+    ASSERT_FALSE(config.Validate());
 }
 
 TEST_F(SharedResourceManagerTest, invalidKey)
@@ -139,7 +142,7 @@ TEST_F(SharedResourceManagerTest, invalidKey)
     PlainConfig config;
     config = getConfig(invalidCertFilePath, keyFilePath);
 
-    ASSERT_FALSE(manager.locateCredentialsWrapper(config));
+    ASSERT_FALSE(config.Validate());
 }
 
 TEST_F(SharedResourceManagerTest, badPermissionsDirectory)
@@ -149,5 +152,6 @@ TEST_F(SharedResourceManagerTest, badPermissionsDirectory)
     config = getConfig(certFilePath, keyFilePath);
     chmod(certDir.c_str(), 0777);
 
+    ASSERT_TRUE(config.Validate());
     ASSERT_FALSE(manager.locateCredentialsWrapper(config));
 }


### PR DESCRIPTION
### Motivation
- If customers accidentally use a placeholder value (or value that cannot be expanded by wordexp) for certain parameters in config file, device client will have a segmentation fault because of ExtractExpandedPath() function.

### Modifications
#### Change summary
- Added checks when parsing config file
- Added a placeholderInput test 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
