### PR TITLE
Fixes CLI parsing bug

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1985,74 +1985,90 @@ constexpr char Config::CLI_CONFIG_FILE[];
 constexpr char Config::DEFAULT_FLEET_PROVISIONING_RUNTIME_CONFIG_FILE[];
 constexpr char Config::DEFAULT_SAMPLE_SHADOW_OUTPUT_DIR[];
 
+bool Config::CheckTerminalArgs(int argc, char **argv)
+{
+    for(int i = 1; i < argc; i++)
+    {
+        std::string currentArg = argv[i];
+        if(currentArg == CLI_HELP)
+        {
+            PrintHelpMessage();
+            return true;
+        }
+        if(currentArg == CLI_VERSION)
+        {
+            PrintVersion();
+            return true;
+        }
+    }
+    return false;
+}
+
 bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 {
     struct ArgumentDefinition
     {
-        string cliFlag;     // Cli flag to look for
+        std::string cliFlag;     // Cli flag to look for
         bool additionalArg; // Does this take an addition argument?
         // cppcheck-suppress unusedStructMember
-        bool stopIfFound; // Should we stop processing more arguments if this is found?
-        std::function<void(const string &additionalArg)> extraSteps; // Function to call if this is found
+        std::function<void(const std::string &additionalArg)> extraSteps; // Function to call if this is found
     };
+
     ArgumentDefinition argumentDefinitions[] = {
-        {CLI_HELP, false, true, [](const string &additionalArg) { PrintHelpMessage(); }},
-        {CLI_VERSION, false, true, [](const string &additionalArg) { PrintVersion(); }},
         {CLI_EXPORT_DEFAULT_SETTINGS,
          true,
-         true,
          [](const string &additionalArg) { ExportDefaultSetting(additionalArg); }},
-        {CLI_CONFIG_FILE, true, false, nullptr},
+        {CLI_CONFIG_FILE, true, nullptr},
 
-        {PlainConfig::CLI_ENDPOINT, true, false, nullptr},
-        {PlainConfig::CLI_CERT, true, false, nullptr},
-        {PlainConfig::CLI_KEY, true, false, nullptr},
-        {PlainConfig::CLI_ROOT_CA, true, false, nullptr},
-        {PlainConfig::CLI_THING_NAME, true, false, nullptr},
+        {PlainConfig::CLI_ENDPOINT, true, nullptr},
+        {PlainConfig::CLI_CERT, true, nullptr},
+        {PlainConfig::CLI_KEY, true, nullptr},
+        {PlainConfig::CLI_ROOT_CA, true, nullptr},
+        {PlainConfig::CLI_THING_NAME, true, nullptr},
 
-        {PlainConfig::LogConfig::CLI_LOG_LEVEL, true, false, nullptr},
-        {PlainConfig::LogConfig::CLI_LOG_TYPE, true, false, nullptr},
-        {PlainConfig::LogConfig::CLI_LOG_FILE, true, false, nullptr},
-        {PlainConfig::LogConfig::CLI_ENABLE_SDK_LOGGING, false, false, nullptr},
-        {PlainConfig::LogConfig::CLI_SDK_LOG_LEVEL, true, false, nullptr},
-        {PlainConfig::LogConfig::CLI_SDK_LOG_FILE, true, false, nullptr},
+        {PlainConfig::LogConfig::CLI_LOG_LEVEL, true, nullptr},
+        {PlainConfig::LogConfig::CLI_LOG_TYPE, true, nullptr},
+        {PlainConfig::LogConfig::CLI_LOG_FILE, true, nullptr},
+        {PlainConfig::LogConfig::CLI_ENABLE_SDK_LOGGING, false, nullptr},
+        {PlainConfig::LogConfig::CLI_SDK_LOG_LEVEL, true, nullptr},
+        {PlainConfig::LogConfig::CLI_SDK_LOG_FILE, true, nullptr},
 
-        {PlainConfig::Jobs::CLI_ENABLE_JOBS, true, false, nullptr},
-        {PlainConfig::Jobs::CLI_HANDLER_DIR, true, false, nullptr},
+        {PlainConfig::Jobs::CLI_ENABLE_JOBS, true, nullptr},
+        {PlainConfig::Jobs::CLI_HANDLER_DIR, true, nullptr},
 
-        {PlainConfig::Tunneling::CLI_ENABLE_TUNNELING, true, false, nullptr},
-        {PlainConfig::Tunneling::CLI_TUNNELING_REGION, true, false, nullptr},
-        {PlainConfig::Tunneling::CLI_TUNNELING_SERVICE, true, false, nullptr},
-        {PlainConfig::Tunneling::CLI_TUNNELING_DISABLE_NOTIFICATION, false, false, nullptr},
+        {PlainConfig::Tunneling::CLI_ENABLE_TUNNELING, true, nullptr},
+        {PlainConfig::Tunneling::CLI_TUNNELING_REGION, true, nullptr},
+        {PlainConfig::Tunneling::CLI_TUNNELING_SERVICE, true, nullptr},
+        {PlainConfig::Tunneling::CLI_TUNNELING_DISABLE_NOTIFICATION, false, nullptr},
 
-        {PlainConfig::DeviceDefender::CLI_ENABLE_DEVICE_DEFENDER, true, false, nullptr},
-        {PlainConfig::DeviceDefender::CLI_DEVICE_DEFENDER_INTERVAL, true, false, nullptr},
+        {PlainConfig::DeviceDefender::CLI_ENABLE_DEVICE_DEFENDER, true, nullptr},
+        {PlainConfig::DeviceDefender::CLI_DEVICE_DEFENDER_INTERVAL, true, nullptr},
 
-        {PlainConfig::FleetProvisioning::CLI_ENABLE_FLEET_PROVISIONING, true, false, nullptr},
-        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_TEMPLATE_NAME, true, false, nullptr},
-        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_TEMPLATE_PARAMETERS, true, false, nullptr},
-        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_CSR_FILE, true, false, nullptr},
-        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_DEVICE_KEY, true, false, nullptr},
+        {PlainConfig::FleetProvisioning::CLI_ENABLE_FLEET_PROVISIONING, true, nullptr},
+        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_TEMPLATE_NAME, true, nullptr},
+        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_TEMPLATE_PARAMETERS, true, nullptr},
+        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_CSR_FILE, true, nullptr},
+        {PlainConfig::FleetProvisioning::CLI_FLEET_PROVISIONING_DEVICE_KEY, true, nullptr},
 
-        {PlainConfig::PubSub::CLI_ENABLE_PUB_SUB, true, false, nullptr},
-        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_TOPIC, true, false, nullptr},
-        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_FILE, true, false, nullptr},
-        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_TOPIC, true, false, nullptr},
-        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_FILE, true, false, nullptr},
+        {PlainConfig::PubSub::CLI_ENABLE_PUB_SUB, true, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_TOPIC, true, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_PUBLISH_FILE, true, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_TOPIC, true, nullptr},
+        {PlainConfig::PubSub::CLI_PUB_SUB_SUBSCRIBE_FILE, true, nullptr},
 
-        {PlainConfig::SampleShadow::CLI_ENABLE_SAMPLE_SHADOW, true, false, nullptr},
-        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_NAME, true, false, nullptr},
-        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_INPUT_FILE, true, false, nullptr},
-        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_OUTPUT_FILE, true, false, nullptr},
+        {PlainConfig::SampleShadow::CLI_ENABLE_SAMPLE_SHADOW, true, nullptr},
+        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_NAME, true, nullptr},
+        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_INPUT_FILE, true, nullptr},
+        {PlainConfig::SampleShadow::CLI_SAMPLE_SHADOW_OUTPUT_FILE, true, nullptr},
 
-        {PlainConfig::ConfigShadow::CLI_ENABLE_CONFIG_SHADOW, true, false, nullptr},
+        {PlainConfig::ConfigShadow::CLI_ENABLE_CONFIG_SHADOW, true, nullptr},
 
-        {PlainConfig::SecureElement::CLI_ENABLE_SECURE_ELEMENT, true, false, nullptr},
-        {PlainConfig::SecureElement::CLI_PKCS11_LIB, true, false, nullptr},
-        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_PIN, true, false, nullptr},
-        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_KEY_LABEL, true, false, nullptr},
-        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_SLOT_ID, true, false, nullptr},
-        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_TOKEN_LABEL, true, false, nullptr}};
+        {PlainConfig::SecureElement::CLI_ENABLE_SECURE_ELEMENT, true, nullptr},
+        {PlainConfig::SecureElement::CLI_PKCS11_LIB, true, nullptr},
+        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_PIN, true, nullptr},
+        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_KEY_LABEL, true, nullptr},
+        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_SLOT_ID, true, nullptr},
+        {PlainConfig::SecureElement::CLI_SECURE_ELEMENT_TOKEN_LABEL, true, nullptr}};
 
     map<string, ArgumentDefinition> argumentDefinitionMap;
     for (auto &i : argumentDefinitions)
@@ -2104,11 +2120,6 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
         if (search->second.extraSteps)
         {
             search->second.extraSteps(additionalArg);
-        }
-
-        if (search->second.stopIfFound)
-        {
-            return false;
         }
     }
     return true;

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -2008,9 +2008,8 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 {
     struct ArgumentDefinition
     {
-        std::string cliFlag; // Cli flag to look for
-        bool additionalArg;  // Does this take an addition argument?
-        // cppcheck-suppress unusedStructMember
+        std::string cliFlag;                                              // Cli flag to look for
+        bool additionalArg;                                               // Does this take an addition argument?
         std::function<void(const std::string &additionalArg)> extraSteps; // Function to call if this is found
     };
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1987,15 +1987,15 @@ constexpr char Config::DEFAULT_SAMPLE_SHADOW_OUTPUT_DIR[];
 
 bool Config::CheckTerminalArgs(int argc, char **argv)
 {
-    for(int i = 1; i < argc; i++)
+    for (int i = 1; i < argc; i++)
     {
         std::string currentArg = argv[i];
-        if(currentArg == CLI_HELP)
+        if (currentArg == CLI_HELP)
         {
             PrintHelpMessage();
             return true;
         }
-        if(currentArg == CLI_VERSION)
+        if (currentArg == CLI_VERSION)
         {
             PrintVersion();
             return true;
@@ -2008,16 +2008,14 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 {
     struct ArgumentDefinition
     {
-        std::string cliFlag;     // Cli flag to look for
-        bool additionalArg; // Does this take an addition argument?
+        std::string cliFlag; // Cli flag to look for
+        bool additionalArg;  // Does this take an addition argument?
         // cppcheck-suppress unusedStructMember
         std::function<void(const std::string &additionalArg)> extraSteps; // Function to call if this is found
     };
 
     ArgumentDefinition argumentDefinitions[] = {
-        {CLI_EXPORT_DEFAULT_SETTINGS,
-         true,
-         [](const string &additionalArg) { ExportDefaultSetting(additionalArg); }},
+        {CLI_EXPORT_DEFAULT_SETTINGS, true, [](const string &additionalArg) { ExportDefaultSetting(additionalArg); }},
         {CLI_CONFIG_FILE, true, nullptr},
 
         {PlainConfig::CLI_ENDPOINT, true, nullptr},

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -446,6 +446,7 @@ namespace Aws
                 static constexpr char CLI_EXPORT_DEFAULT_SETTINGS[] = "--export-default-settings";
                 static constexpr char CLI_CONFIG_FILE[] = "--config-file";
 
+                static bool CheckTerminalArgs(int argc, char *argv[]);
                 static bool ParseCliArgs(int argc, char *argv[], CliArgs &cliArgs);
                 bool ValidateAndStoreRuntimeConfig();
                 bool ParseConfigFile(const std::string &file, bool isRuntimeConfig);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -305,7 +305,7 @@ namespace Aws
 int main(int argc, char *argv[])
 {
     CliArgs cliArgs;
-    if(Config::CheckTerminalArgs(argc, argv))
+    if (Config::CheckTerminalArgs(argc, argv))
     {
         LoggerFactory::getLoggerInstance()->shutdown();
         return 0;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -305,10 +305,15 @@ namespace Aws
 int main(int argc, char *argv[])
 {
     CliArgs cliArgs;
-    if (!Config::ParseCliArgs(argc, argv, cliArgs) || !config.init(cliArgs))
+    if(Config::CheckTerminalArgs(argc, argv))
     {
         LoggerFactory::getLoggerInstance()->shutdown();
         return 0;
+    }
+    if (!Config::ParseCliArgs(argc, argv, cliArgs) || !config.init(cliArgs))
+    {
+        LoggerFactory::getLoggerInstance()->shutdown();
+        return 1;
     }
 
     if (!LoggerFactory::reconfigure(config.config) &&


### PR DESCRIPTION
### Motivation
CLI Arg parsing errors were returning 0, this fixes that by separating the help/version arg checks to a different method

### Testing
```
dev-dsk-shangabl-2b-cfbafac5 % ./aws-iot-device-client --foo
2022-07-07T20:07:26.651Z [ERROR] {Config.cpp}: *** AWS IOT DEVICE CLIENT FATAL ERROR: Unrecognised command line argument: --foo ***

(22-07-07 20:07:26) <1> [/tmp/deviceclient/cmake-build-debug]  
dev-dsk-shangabl-2b-cfbafac5 % echo $?
1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
