### PR TITLE
Replace third party clang format action with clang-format from ci image

### DIFF
--- a/.github/docker-images/ubuntu-18-x64/Dockerfile
+++ b/.github/docker-images/ubuntu-18-x64/Dockerfile
@@ -10,6 +10,7 @@ ARG OPENSSL_VERSION=1.1.1n
 RUN apt-get update -qq \
     && apt-get -y install \
     git \
+    clang-format \
     curl \
     build-essential \
     wget \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
     - name: Checkout Sources
       uses: actions/checkout@v1
-
-    - name: clang-format lint
-      uses: DoozyX/clang-format-lint-action@v0.3.1
-      with:
-        # List of extensions to check
-        extensions: cpp,h
+    - name: cppcheck script
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
+        export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest
+        docker pull $DOCKER_IMAGE
+        docker run --mount type=bind,source=$(pwd),target=/src --workdir /src --entrypoint /src/format-check.sh $DOCKER_IMAGE
 
   cppcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Checkout Sources
       uses: actions/checkout@v1
-    - name: cppcheck script
+    - name: clang-format script
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u awslabs --password-stdin
         export DOCKER_IMAGE=ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest


### PR DESCRIPTION
### Motivation
Our CI build uses clang-format lint check provided by third party. The behavior of clang-format changes from version to version. When clang-format lint check fails, then we have to install the same version locally as the version used by the third party. Instead it would be easier if we install clang-format in one of our CI images so that we can reproduce clang-format failures locally.

### Modifications
#### Change summary
Use clang-format installed on the `ghcr.io/awslabs/aws-iot-device-client/ubuntu-18-x64:latest` image.

### Testing
Tested by CI build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
