### PR TITLE
Rolling back failing changes made for runAsUser.

### DIFF
--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -260,27 +260,13 @@ int JobEngine::exec_cmd(const string &operation, PlainJobDocument::JobAction act
     {
         argSize = action.input.args->size();
     }
-    std::unique_ptr<const char *[]> argv;
-    if (action.runAsUser.has_value() && !action.runAsUser->empty())
+    std::unique_ptr<const char *[]> argv(new const char *[argSize + 3]);
+    argv[0] = operation.c_str();
+    argv[1] = action.runAsUser->c_str();
+    argv[argSize + 2] = nullptr;
+    for (size_t i = 0; i < argSize; i++)
     {
-        argv.reset(new const char *[argSize + 3]);
-        argv[0] = operation.c_str();
-        argv[1] = action.runAsUser->c_str();
-        argv[argSize + 2] = nullptr;
-        for (size_t i = 0; i < argSize; i++)
-        {
-            argv[i + 2] = action.input.args->at(i).c_str();
-        }
-    }
-    else
-    {
-        argv.reset(new const char *[argSize + 2]);
-        argv[0] = operation.c_str();
-        argv[argSize + 1] = nullptr;
-        for (size_t i = 0; i < argSize; i++)
-        {
-            argv[i + 1] = action.input.args->at(i).c_str();
-        }
+        argv[i + 2] = action.input.args->at(i).c_str();
     }
 
     int execResult;

--- a/test/jobs/TestJobEngine.cpp
+++ b/test/jobs/TestJobEngine.cpp
@@ -102,21 +102,6 @@ TEST_F(TestJobEngine, ExecuteStepsHappy)
     ASSERT_STREQ(jobEngine.getStdOut().c_str(), std::string(testStdout + "\n").c_str());
 }
 
-TEST_F(TestJobEngine, ExecuteWithoutRunAsUser)
-{
-    vector<PlainJobDocument::JobAction> steps;
-    vector<std::string> args;
-    args.push_back("-c");
-    args.push_back("echo " + testStdout);
-    steps.push_back(createJobAction("testAction", "runHandler", "sh", args, "/bin", false));
-    PlainJobDocument jobDocument = createTestJobDocument(steps, true);
-    JobEngine jobEngine;
-
-    int executionStatus = jobEngine.exec_steps(jobDocument, testHandlerDirectoryPath);
-    ASSERT_EQ(executionStatus, 0);
-    ASSERT_STREQ(jobEngine.getStdOut().c_str(), std::string(testStdout + "\n").c_str());
-}
-
 TEST_F(TestJobEngine, ExecuteSucceedThenFail)
 {
     vector<PlainJobDocument::JobAction> steps;


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: #282 

Device Client's Jobs feature is coded in a way that to execute the job Execution, the argument list passed to `execv` command is in the following order:

```
argv[0] executable path
argv[1] Linux user name
argv[2:] arguments required for executing the executable file..
```

If `runAsUser` value is not passed or is empty string, DC will pass it as empty string to `execv`  because it is considered as a separate argument by shell script. In bellow example, we passed empty string for `runAsUser`   argument which is passed as empty string to the install-packages.sh script and is handled properly by the Job Handler. 

```
2022-07-15T19:29:38.848Z [DEBUG] {13126}: Running install-packages.sh
2022-07-15T19:29:38.848Z [DEBUG] {13126}: **Username:** 
2022-07-15T19:29:38.848Z [DEBUG] {13126}: Packages to install: lftp
2022-07-15T19:29:38.848Z [DEBUG] {13126}: Using apt-get for package install
2022-07-15T19:29:38.850Z [DEBUG] {13126}: username or sudo command not found
```


### Modifications
#### Change summary

Since Job Handlers written by our team is expecting us to pass value for `runAsUser` or `username` var in shell scrips, we are rolling back the changes as they were earlier to resolve the new issues created. If we don't rollback these changes, all of the Job handlers will fail if empty value is passed for `runAsUser`.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
Manually tested and also ran integration tests against this change. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
