### PR TITLE
 Remove ProxyUtils related class from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ endif ()
 ###############################################
 ## Build the AWS IoT Device Client Executable #
 ###############################################
-add_executable(${DC_PROJECT_NAME} ${DC_SRC} source/util/ProxyUtils.cpp source/util/ProxyUtils.h)
+add_executable(${DC_PROJECT_NAME} ${DC_SRC})
 set_target_properties(${DC_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_definitions(${DC_PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
 ## We need to add the project binary directory to the list of include directories

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,7 @@ list(APPEND DC_SRC ${DC_TST})
 list(FILTER DC_SRC EXCLUDE REGEX ".*main.cpp$")
 
 set(HEADERS)
-add_executable(${GTEST_PROJECT} ${DC_SRC} util/TestProxyUtils.cpp)
+add_executable(${GTEST_PROJECT} ${DC_SRC})
 
 if (NOT EXCLUDE_JOBS)
     target_link_libraries(${GTEST_PROJECT} IotJobs-cpp)


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: 


### Modifications
#### Change summary
The changes for the [http proxy](https://github.com/awslabs/aws-iot-device-client/commit/e19af866fa02d1651eb3debb7e7348fb95d0fde7) contains an unexpected change that adding ProxyUtil related class into the CMakeLists.txt. Since they're already included by the definition. Those lines are not needed. 

I think it's the one of the Clion formatter triggering that.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
