### PR TITLE
Disable sensor publish feature for secure tunnel builds

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -103,7 +103,7 @@ cd ./build/
 case $compileMode in
     st_component_mode)
     echo "Building in ST component mode"
-    cmake ../ -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SDK=ON -DBUILD_TEST_DEPS=OFF -DLINK_DL=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON
+    cmake ../ -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SDK=ON -DBUILD_TEST_DEPS=OFF -DLINK_DL=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON -DEXCLUDE_SENSOR_PUBLISH=ON
     ;;
     armhf_cross_mode)
     apt-get update
@@ -125,7 +125,7 @@ case $compileMode in
     cd ..
     if [ "$stMode" = true ]; then
       # Set CMake flags for ST mode
-      cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake -DBUILD_SDK=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON ../
+      cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake -DBUILD_SDK=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON -DEXCLUDE_SENSOR_PUBLISH=ON ../
     elif [ "$sharedLibs" = true ]; then
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-armhf.cmake -DBUILD_SDK=ON ../
       make install DESTDIR=./shared_install_dir
@@ -188,7 +188,7 @@ case $compileMode in
     cd ..
     if [ "$stMode" = true ]; then
       # Set CMake flags for ST mode
-      cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake -DBUILD_SDK=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON ../
+      cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake -DBUILD_SDK=ON -DEXCLUDE_JOBS=ON -DEXCLUDE_DD=ON -DEXCLUDE_FP=ON -DDISABLE_MQTT=ON -DEXCLUDE_SENSOR_PUBLISH=ON ../
     elif [ "$sharedLibs" = true ]; then
       cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/Toolchain-aarch64.cmake -DBUILD_SDK=ON ../
       make install DESTDIR=./shared_install_dir

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1258,7 +1258,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigAddr)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid permissions on addr.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1290,7 +1292,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Empty mqtt_topic.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1321,8 +1325,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
 
     PlainConfig config;
     config.LoadFromJson(jsonView);
-
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1354,7 +1359,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid eom_delimiter.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1390,7 +1397,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigNegativeIntegers)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid integer values.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1423,7 +1432,9 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigBufferCapacityTooSmall)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Buffer capacity too small.
+#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
@@ -1456,7 +1467,9 @@ TEST_F(ConfigTestFixture, SensorPublishDisableFeature)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
+#if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // All sensors disabled, then disable feature.
+#endif
     ASSERT_FALSE(config.sensorPublish.enabled);
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1258,7 +1258,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigAddr)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Invalid permissions on addr.
@@ -1293,7 +1293,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Empty mqtt_topic.
@@ -1328,7 +1328,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
@@ -1363,7 +1363,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Invalid eom_delimiter.
@@ -1402,7 +1402,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigNegativeIntegers)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Invalid integer values.
@@ -1438,7 +1438,7 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigBufferCapacityTooSmall)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // Buffer capacity too small.
@@ -1474,7 +1474,7 @@ TEST_F(ConfigTestFixture, SensorPublishDisableFeature)
     PlainConfig config;
     config.LoadFromJson(jsonView);
 
-#if !defined(EXCLUDE_SENSOR_PUBLISH)
+#if defined(EXCLUDE_SENSOR_PUBLISH)
     GTEST_SKIP();
 #endif
     ASSERT_FALSE(config.Validate()); // All sensors disabled, then disable feature.

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1259,9 +1259,10 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigAddr)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Invalid permissions on addr.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1293,9 +1294,10 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Empty mqtt_topic.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1325,10 +1327,12 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
 
     PlainConfig config;
     config.LoadFromJson(jsonView);
+
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1360,9 +1364,10 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Invalid eom_delimiter.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1398,9 +1403,10 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigNegativeIntegers)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Invalid integer values.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1433,9 +1439,10 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigBufferCapacityTooSmall)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // Buffer capacity too small.
     ASSERT_TRUE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1468,9 +1475,10 @@ TEST_F(ConfigTestFixture, SensorPublishDisableFeature)
     config.LoadFromJson(jsonView);
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
+    GTEST_SKIP();
+#endif
     ASSERT_FALSE(config.Validate()); // All sensors disabled, then disable feature.
     ASSERT_FALSE(config.sensorPublish.enabled);
-#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1260,8 +1260,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigAddr)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid permissions on addr.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1294,8 +1294,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Empty mqtt_topic.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1327,8 +1327,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
     config.LoadFromJson(jsonView);
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1361,8 +1361,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid eom_delimiter.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1399,8 +1399,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigNegativeIntegers)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Invalid integer values.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1434,8 +1434,8 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigBufferCapacityTooSmall)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // Buffer capacity too small.
-#endif
     ASSERT_TRUE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);
@@ -1469,8 +1469,8 @@ TEST_F(ConfigTestFixture, SensorPublishDisableFeature)
 
 #if !defined(EXCLUDE_SENSOR_PUBLISH)
     ASSERT_FALSE(config.Validate()); // All sensors disabled, then disable feature.
-#endif
     ASSERT_FALSE(config.sensorPublish.enabled);
+#endif
     ASSERT_EQ(config.sensorPublish.settings.size(), 1);
     const auto &settings = config.sensorPublish.settings[0];
     ASSERT_FALSE(settings.enabled);


### PR DESCRIPTION
### Motivation
- Exclude sensor publish feature when building device client binary exclusively for secure tunnel eg `st_component_mode`.


### Modifications
- When `EXCLUDE_SENSOR_PUBLISH=ON` then disable sensor publish configuration validation checks in unit tests.

### Testing
- Unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
