### PR TITLE
Ignore correct docs folder, and update readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ out/
 build/
 
 # Ignore compiled documentation folders
-doc/html/
-doc/latex/
+docs/html/
+docs/latex/
 
 # Intellij
 .idea/

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ sudo apt-get install doxygen
 Once Doxygen is installed on your machine, you can generate the documentation as follows:
 
 ```
-cd doc # Navigate into the documentation folder
+cd docs # Navigate into the documentation folder
 doxygen # Doxygen bin generates HTML and Latex output
 ```
 


### PR DESCRIPTION
### Motivation
Noticed that gitignore and readme both referenced doc folder, when it's actually docs.


### Modifications
#### Change summary
Fix gitignore and readme to use docs instead of doc
#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
Minimally tested. No change to code files.
Follow readme
cd docs
docygen
generated files don't show up in git changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
