### PR TITLE
wrapping shell-command job into shell-command-handler.sh

### DIFF
--- a/sample-job-handlers/shell-command-handler.sh
+++ b/sample-job-handlers/shell-command-handler.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
+echo "Running shell-command-handler.sh"
+user=$1
+shift 1
+echo "Username: $user"
+if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
+    sudo -u "$user" -n $@
+else
+    echo "username or sudo command not found"
+    $@
+fi

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -139,21 +139,20 @@ void JobEngine::exec_action(PlainJobDocument::JobAction action, const std::strin
     string command;
     if (action.type == PlainJobDocument::ACTION_TYPE_RUN_HANDLER)
     {
-        try{
+        try
+        {
             // build command for shell command
             if (action.name == "shell-command")
             {
                 command = buildCommand(jobHandlerDir, "shell-command-handler.sh", jobHandlerDir);
-
             }
             else
             {
                 // build command for standard jobHandler
                 command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
-
             }
-
-        }catch (exception &e)
+        }
+        catch (exception &e)
         {
             if (!action.ignoreStepFailure.value())
             {

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -141,16 +141,24 @@ void JobEngine::exec_action(PlainJobDocument::JobAction action, const std::strin
     {
         try
         {
+            // build command for standard jobHandler
+            command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
+        }
+        catch (exception &e)
+        {
+            if (!action.ignoreStepFailure.value())
+            {
+                executionStatus = 1;
+            }
+            return;
+        }
+    }
+    else if (action.type == "runShellCommand")
+    {
+        try
+        {
             // build command for shell command
-            if (action.name == "shell-command")
-            {
-                command = buildCommand(jobHandlerDir, "shell-command-handler.sh", jobHandlerDir);
-            }
-            else
-            {
-                // build command for standard jobHandler
-                command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
-            }
+            command = buildCommand(jobHandlerDir, "shell-command-handler.sh", jobHandlerDir);
         }
         catch (exception &e)
         {

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -139,18 +139,37 @@ void JobEngine::exec_action(PlainJobDocument::JobAction action, const std::strin
     string command;
     if (action.type == PlainJobDocument::ACTION_TYPE_RUN_HANDLER)
     {
-        // build command
-        try
+        // build command for shell command
+        if (action.name == "shell-command")
         {
-            command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
-        }
-        catch (exception &e)
-        {
-            if (!action.ignoreStepFailure.value())
+            try
             {
-                executionStatus = 1;
+                command = buildCommand(jobHandlerDir, "shell-command-handler.sh", jobHandlerDir);
             }
-            return;
+            catch (exception &e)
+            {
+                if (!action.ignoreStepFailure.value())
+                {
+                    executionStatus = 1;
+                }
+                return;
+            }
+        }
+        else
+        {
+            // build command for standard jobHandler
+            try
+            {
+                command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
+            }
+            catch (exception &e)
+            {
+                if (!action.ignoreStepFailure.value())
+                {
+                    executionStatus = 1;
+                }
+                return;
+            }
         }
     }
     else

--- a/source/jobs/JobEngine.cpp
+++ b/source/jobs/JobEngine.cpp
@@ -139,37 +139,27 @@ void JobEngine::exec_action(PlainJobDocument::JobAction action, const std::strin
     string command;
     if (action.type == PlainJobDocument::ACTION_TYPE_RUN_HANDLER)
     {
-        // build command for shell command
-        if (action.name == "shell-command")
-        {
-            try
+        try{
+            // build command for shell command
+            if (action.name == "shell-command")
             {
                 command = buildCommand(jobHandlerDir, "shell-command-handler.sh", jobHandlerDir);
+
             }
-            catch (exception &e)
+            else
             {
-                if (!action.ignoreStepFailure.value())
-                {
-                    executionStatus = 1;
-                }
-                return;
-            }
-        }
-        else
-        {
-            // build command for standard jobHandler
-            try
-            {
+                // build command for standard jobHandler
                 command = buildCommand(action.input.path, action.input.handler, jobHandlerDir);
+
             }
-            catch (exception &e)
+
+        }catch (exception &e)
+        {
+            if (!action.ignoreStepFailure.value())
             {
-                if (!action.ignoreStepFailure.value())
-                {
-                    executionStatus = 1;
-                }
-                return;
+                executionStatus = 1;
             }
+            return;
         }
     }
     else

--- a/source/jobs/README.md
+++ b/source/jobs/README.md
@@ -358,6 +358,41 @@ We recommend avoiding execution of any jobs that may reveal or leak sensitive in
 , private keys, or sensitive files as well as assignment of appropriately restrictive permissions for your credentials
 /sensitive files. 
 
+### Running Shell-command jobs
+
+When running a shell-command job, for instance: creating a new file under `tmp` directory using `touch /temp/new-file`. You can follow
+similar steps in `Creating Your Own Job Handler`. The difference are:
+
+1. `shell-command-handler` is already created under `sample-job-handler` directory if you have copied entire directory during setup. All you need to do is to create a job document for the shell-command.
+2. `action.name` needs to be `shell-command` in order to invoke `shell-command-handler.sh` from `sample-job-handler` directory.
+3. `handler`'s value needs to be `shell-command-handler.sh`
+
+**Sample shell-command job document**
+```
+{
+    "version": "1.0",
+    "steps": [
+      {
+        "action": {
+          "name": "shell-command",
+          "type": "runHandler",
+          "input": {
+            "handler": "shell-command-handler.sh",
+            "args": [
+              "touch",
+              "/tmp/new-file"
+            ],
+            "path": ""
+          },
+          runAsUser: "root" 
+        }
+      }
+    ]
+  }
+``` 
+
+**Note: In the shell-command job document, `path` is not required since it will always invoke `shell-command-handler.sh` under `sample-job-handler` directory. `runAsUser` is an optional field.**
+
 ### Debugging your Job
 
 Once you've set up your job handlers and started targeting your thing or thing group with jobs, you may need to perform

--- a/source/jobs/README.md
+++ b/source/jobs/README.md
@@ -363,8 +363,8 @@ We recommend avoiding execution of any jobs that may reveal or leak sensitive in
 When running a shell-command job, for instance: creating a new file under `tmp` directory using `touch /temp/new-file`. You can follow
 similar steps in `Creating Your Own Job Handler`. The difference are:
 
-1. `shell-command-handler` is already created under `sample-job-handler` directory if you have copied entire directory during setup. All you need to do is to create a job document for the shell-command.
-2. `action.name` needs to be `shell-command` in order to invoke `shell-command-handler.sh` from `sample-job-handler` directory.
+1. `shell-command-handler.sh` is already created under `sample-job-handler` directory if you have copied entire directory during setup. All you need to do is to create a job document for the shell-command.
+2. `action.type` needs to be `runShellCommand` in order to invoke `shell-command-handler.sh` from `sample-job-handler` directory.
 3. `handler`'s value needs to be `shell-command-handler.sh`
 
 **Sample shell-command job document**
@@ -374,8 +374,8 @@ similar steps in `Creating Your Own Job Handler`. The difference are:
     "steps": [
       {
         "action": {
-          "name": "shell-command",
-          "type": "runHandler",
+          "name": "create-file",
+          "type": "runShellCommand",
           "input": {
             "handler": "shell-command-handler.sh",
             "args": [

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,3 +135,11 @@ if (VALGRIND_PATH)
         COMMAND ${VALGRIND_PATH} --leak-check=yes --error-exitcode=1 ./${GTEST_PROJECT}
         DEPENDS ${GTEST_PROJECT})
 endif()
+
+# Add custom target for copying sample-job-handlers to build directory for use with unit tests.
+add_custom_target(
+    copy-sample-job-handlers
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/sample-job-handlers ${CMAKE_BINARY_DIR}/sample-job-handlers
+    COMMENT "copying sample-job-handlers to build directory")
+# Make unit test binary depend on this target.
+add_dependencies(${GTEST_PROJECT} copy-sample-job-handlers)

--- a/test/jobs/TestJobEngine.cpp
+++ b/test/jobs/TestJobEngine.cpp
@@ -173,7 +173,8 @@ TEST_F(TestJobEngine, ExecuteShellCommandHandlerWithoutUser)
     vector<std::string> args;
     args.push_back("touch");
     args.push_back(testHandlerDirectoryPath + "/test-success");
-    steps.push_back(createJobAction("shell-command", "runHandler", "shell-command-handler.sh", args, "", NULL, false));
+    steps.push_back(
+        createJobAction("create-file", "runShellCommand", "shell-command-handler.sh", args, "", NULL, false));
     PlainJobDocument jobDocument = createTestJobDocument(steps, true);
     JobEngine jobEngine;
 
@@ -188,7 +189,7 @@ TEST_F(TestJobEngine, ExecuteShellCommandHandlerWithEmptyUser)
     vector<std::string> args;
     args.push_back("touch");
     args.push_back(testHandlerDirectoryPath + "/test-success");
-    steps.push_back(createJobAction("shell-command", "runHandler", "shell-command-handler.sh", args, "", "", false));
+    steps.push_back(createJobAction("create-file", "runShellCommand", "shell-command-handler.sh", args, "", "", false));
     PlainJobDocument jobDocument = createTestJobDocument(steps, true);
     JobEngine jobEngine;
 
@@ -204,7 +205,7 @@ TEST_F(TestJobEngine, ExecuteShellCommandHandlerWithUser)
     args.push_back("touch");
     args.push_back(testHandlerDirectoryPath + "/test-success");
     steps.push_back(
-        createJobAction("shell-command", "runHandler", "shell-command-handler.sh", args, "", "root", false));
+        createJobAction("create-file", "runShellCommand", "shell-command-handler.sh", args, "", "root", false));
     PlainJobDocument jobDocument = createTestJobDocument(steps, true);
     JobEngine jobEngine;
 


### PR DESCRIPTION
### Motivation
- JobEngine is not supporting running shell-command jobs, this change provides a work around by wrapping shell-command job using one of the sample-job-handler: shell-command-handler.sh
- Issue number: #282 


### Modifications
#### Change summary
Invoking shell-command-handler.sh when action.name = "shell-command"

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
