### PR TITLE
resolved error caused by calling same promise variable more than one time

### DIFF
--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -363,6 +363,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     }
 
     promise<int> connectionCompletedPromise;
+    connectionClosedPromise = std::promise<void>();
 
     /*
      * This will execute when an mqtt connect has completed or failed.


### PR DESCRIPTION

### Motivation
- Please give a brief description for the background of this change.
- Issue number: 
- In SharedCrtResourceManager class, we were calling same promise variable more than one time while closing MQTT connection. 


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 
- Updated the logic to initialize new promise variable every time connection is established.  

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>
- Tested manually. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
