### PR TITLE
Updated runtime config file permission

### DIFF
--- a/source/fleetprovisioning/FleetProvisioning.cpp
+++ b/source/fleetprovisioning/FleetProvisioning.cpp
@@ -714,7 +714,7 @@ bool FleetProvisioning::ExportRuntimeConfig(
         runtimeDeviceConfig.c_str());
     LOGM_INFO(TAG, "Exported runtime configurations to: %s", file.c_str());
 
-    chmod(expandedPath.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    chmod(expandedPath.c_str(), S_IRUSR | S_IWUSR | S_IRGRP);
     FileUtils::ValidateFilePermissions(expandedPath.c_str(), Permissions::RUNTIME_CONFIG_FILE, false);
     return true;
 }


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
The runtime config file created in device client's fleet provisioning feature was incorrect. Updated the file permission from `644` to `640`


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
