### PR TITLE
Removed ECR image links (#348)

### DIFF
--- a/.github/docker-images/README.md
+++ b/.github/docker-images/README.md
@@ -5,19 +5,10 @@ The AWS IoT Device Client provides several Docker images to simplify testing and
 ## Base Images
 
 The base images are built from the Docker files located in the [base-images](./base-images) directory. These images contain
-the dependencies of the Device Client only and are intended to be used to build & run the Device Client. Pre-built base
-images are publicly available through AWS ECR in the [aws-iot-device-client-base-images repository](https://gallery.ecr.aws/aws-iot-device-client/aws-iot-device-client-base-images).
-
-## AWS IoT Device Client Images
-
-Docker images containing Device Client binaries are also available through ECR. These images are built using this [Dockerfile](./Dockerfile)
-and are multi-stage builds that are minimum sized. Images are built from both the pre-release and main branches. The pre-release
-images are available for testing and experimenting with features which are still in development from the [pre-release repository](https://gallery.ecr.aws/aws-iot-device-client/pre-release).
-Images built from the main branch are available from the [aws-iot-device-client repository](https://gallery.ecr.aws/aws-iot-device-client/aws-iot-device-client).
+the dependencies of the Device Client only and are intended to be used to build & run the Device Client.
 
 ## Integration Test Images
 
 Before releasing new features on the main branch end-to-end tests are performed in the pre-release branch. As part of this
 process the Docker files located in the [integration-tests](./integration-tests) directory are used to build and run the
-end-to-end tests. In order to make it easy to recreate any test failures locally, these images are pushed to the [integration-tests repository](https://gallery.ecr.aws/aws-iot-device-client/integration-tests).
-These images contain both the pre-release version of the Device Client and the integration test binary.
+end-to-end tests.

--- a/README.md
+++ b/README.md
@@ -75,13 +75,10 @@ The AWS IoT Device Client is currently compatible with x86_64, aarch64, armv7l, 
 
 ### Docker
 
-The AWS IoT Device Client currently provides several docker images on various platforms and Linux distributions.
+The AWS IoT Device Client currently provides several dockerfiles for various platforms and Linux distributions.
 
 To build a Docker image from the repository locally simply run the [docker-build.sh](docker-build.sh) script with your
 preferred OS (ubuntu/amazonlinux/ubi8) (e.g. docker-build.sh ubuntu) if no OS is passed the build will default to ubuntu (18.04).
-
-For a minimum sized fully built AWS IoT Device Client Docker image simply pull your preferred architecture/OS combination
-from our repository [here](https://gallery.ecr.aws/aws-iot-device-client/aws-iot-device-client)
 
 #### Docker Files
 


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
Removed the links to ECR docker images.



#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
