### PR TITLE
fix memory leak in pubsub

### DIFF
--- a/source/samples/pubsub/PubSubFeature.cpp
+++ b/source/samples/pubsub/PubSubFeature.cpp
@@ -169,6 +169,7 @@ void PubSubFeature::publishFileData()
     if (getPublishFileData(&payload) != AWS_OP_SUCCESS)
     {
         LOG_ERROR(TAG, "Failed to read publish file... Skipping publish");
+        aws_byte_buf_clean_up_secure(&payload);
         return;
     }
     auto onPublishComplete = [payload, this](const Mqtt::MqttConnection &, uint16_t, int errorCode) mutable {


### PR DESCRIPTION
### Motivation
- Default publish payload previously not formatted as JSON (already merged)
- one line addition to fix a minor memory leak

### Modifications
#### Change summary
Please describe what changes are included in this pull request. 
- Update default publish payload using JSON formatted string (EDIT: has already been added)
- fix minor memory leak
- code quality improvements (EDIT: has been added from the sonarcloud PR)

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
- verified using mqtt test client


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
