### PR TITLE
shadow fix and plug pubsub memory leak

### DIFF
--- a/source/samples/pubsub/PubSubFeature.cpp
+++ b/source/samples/pubsub/PubSubFeature.cpp
@@ -169,6 +169,7 @@ void PubSubFeature::publishFileData()
     if (getPublishFileData(&payload) != AWS_OP_SUCCESS)
     {
         LOG_ERROR(TAG, "Failed to read publish file... Skipping publish");
+        aws_byte_buf_clean_up_secure(&payload);
         return;
     }
     auto onPublishComplete = [payload, this](const Mqtt::MqttConnection &, uint16_t, int errorCode) mutable {

--- a/source/shadow/SampleShadowFeature.cpp
+++ b/source/shadow/SampleShadowFeature.cpp
@@ -392,7 +392,6 @@ void SampleShadowFeature::readAndUpdateShadowFromFile()
 
     ShadowState state;
     state.Reported = jsonObj;
-    state.Desired = jsonObj;
     updateNamedShadowRequest.State = state;
 
     Aws::Crt::UUID uuid;


### PR DESCRIPTION
### Motivation
- While not intended to alter the feature behavior fundamentally, removes updating the desired state upon startup.
- Issue number: #358


### Modifications
#### Change summary
Deletes the line that sets desired state to the Json object.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
