### PR TITLE
Remove null terminator from formatted string

### DIFF
--- a/source/fleetprovisioning/FleetProvisioning.cpp
+++ b/source/fleetprovisioning/FleetProvisioning.cpp
@@ -700,7 +700,8 @@ bool FleetProvisioning::ExportRuntimeConfig(
         LOGM_ERROR(TAG, "*** %s: Unable to open file: '%s' ***", DeviceClient::DC_FATAL_ERROR, file.c_str());
         return false;
     }
-    clientConfig << FormatMessage(
+
+    string formattedMsg = FormatMessage(
         jsonTemplate.c_str(),
         PlainConfig::JSON_KEY_RUNTIME_CONFIG,
         PlainConfig::FleetProvisioningRuntimeConfig::JSON_KEY_COMPLETED_FLEET_PROVISIONING,
@@ -712,6 +713,9 @@ bool FleetProvisioning::ExportRuntimeConfig(
         runtimeThingName.c_str(),
         PlainConfig::FleetProvisioningRuntimeConfig::JSON_KEY_DEVICE_CONFIG,
         runtimeDeviceConfig.c_str());
+
+    LOG_DEBUG(TAG, formattedMsg.c_str());
+    clientConfig << formattedMsg;
     LOGM_INFO(TAG, "Exported runtime configurations to: %s", file.c_str());
 
     chmod(expandedPath.c_str(), S_IRUSR | S_IWUSR | S_IRGRP);

--- a/source/util/StringUtils.cpp
+++ b/source/util/StringUtils.cpp
@@ -28,14 +28,13 @@ namespace Aws
                     // truncated
                     formattedMsgSize = std::min(formattedMsgSize, Config::MAX_CONFIG_SIZE - 1) + 1;
 
-                    std::string buffer;
-                    buffer.resize(formattedMsgSize);
+                    std::unique_ptr<char[]> buffer(new char[formattedMsgSize]);
 
                     va_copy(copy, args);
-                    vsnprintf(&buffer[0], formattedMsgSize, message, copy);
+                    vsnprintf(buffer.get(), formattedMsgSize, message, copy);
                     va_end(copy);
 
-                    return buffer;
+                    return string(buffer.get(), buffer.get() + formattedMsgSize - 1);
                 }
 
                 string FormatMessage(const char message[], ...)

--- a/test/util/TestStringUtils.cpp
+++ b/test/util/TestStringUtils.cpp
@@ -30,7 +30,7 @@ TEST(StringUtils, FormatStringTruncate)
 {
     string s(Config::MAX_CONFIG_SIZE + 1234, '*');
     string actual = FormatMessage(s.c_str());
-    ASSERT_EQ(actual.size(), Config::MAX_CONFIG_SIZE);
+    ASSERT_EQ(actual.size(), Config::MAX_CONFIG_SIZE - 1);
 }
 
 TEST(StringUtils, sanitizeRemovesFormatSpecifier)


### PR DESCRIPTION
### Motivation
- Exporting the runtime config during fleet provisioning adds the null terminator character from the string format function, which shows up as ^@ in the file.

### Modifications
- changes remove this character from the string returned by FormatMessage()


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
