### PR TITLE
Upgrade boost to 1.79 for ST tests

### DIFF
--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -22,9 +22,9 @@ RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	make install && \
 	cd /home/dependencies
 
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -O /tmp/boost.tar.gz && \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz -O /tmp/boost.tar.gz && \
 	tar xzvf /tmp/boost.tar.gz && \
-	cd boost_1_76_0 && \
+	cd boost_1_79_0 && \
 	./bootstrap.sh && \
 	./b2 install link=static && \
 	cd /home/dependencies


### PR DESCRIPTION
### Motivation
- Secure Tunneling Local Proxy Requires boost 1.79 now. Needed for integration tests.


### Modifications
#### Change summary
Upgraded boost in the integration test docker images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
