### PR TITLE
Fix infinite restart loop for Device Client

### DIFF
--- a/integration-tests/source/jobs/JobsIntegrationTests.cpp
+++ b/integration-tests/source/jobs/JobsIntegrationTests.cpp
@@ -36,6 +36,11 @@ static constexpr char VERIFY_PACKAGES_REMOVED_JOB_DOC[] =
 static constexpr char RUN_COMMAND_PRINT_GREETING_JOB_DOC[] =
     "{ \"version\": \"1.0\", \"steps\": [ { \"action\": { \"name\": \"Print Greeting\", \"type\": "
     "\"runCommand\", \"input\": { \"command\": \"echo,Hello World\" }, \"runAsUser\": \"root\" } }]}";
+static constexpr char RESTART_SERVICES_JOB_DOC[] =
+    "{ \"version\": \"1.0\", \"steps\": [ { \"action\": { \"name\": \"Restart Services\", \"type\": \"runHandler\", "
+    "\"input\": { \"handler\": \"restart-services.sh\", \"args\": [ \"aws-iot-device-client\" ], \"path\": \"default\" "
+    "}, "
+    "\"runAsUser\": \"root\" } }]}";
 
 class TestJobsFixture : public ::testing::Test
 {
@@ -90,6 +95,14 @@ TEST_F(TestJobsFixture, PrintGreeting)
 {
     string jobId = "Print-Greeting-" + resourceHandler->GetTimeStamp();
     resourceHandler->CreateJob(jobId, RUN_COMMAND_PRINT_GREETING_JOB_DOC);
+
+    ASSERT_EQ(resourceHandler->GetJobExecutionStatusWithRetry(jobId), JobExecutionStatus::SUCCEEDED);
+}
+
+TEST_F(TestJobsFixture, RestartServices)
+{
+    string jobId = "Restart-Services-" + resourceHandler->GetTimeStamp();
+    resourceHandler->CreateJob(jobId, RESTART_SERVICES_JOB_DOC);
 
     ASSERT_EQ(resourceHandler->GetJobExecutionStatusWithRetry(jobId), JobExecutionStatus::SUCCEEDED);
 }

--- a/integration-tests/source/jobs/JobsIntegrationTests.cpp
+++ b/integration-tests/source/jobs/JobsIntegrationTests.cpp
@@ -36,11 +36,6 @@ static constexpr char VERIFY_PACKAGES_REMOVED_JOB_DOC[] =
 static constexpr char RUN_COMMAND_PRINT_GREETING_JOB_DOC[] =
     "{ \"version\": \"1.0\", \"steps\": [ { \"action\": { \"name\": \"Print Greeting\", \"type\": "
     "\"runCommand\", \"input\": { \"command\": \"echo,Hello World\" }, \"runAsUser\": \"root\" } }]}";
-static constexpr char RESTART_SERVICES_JOB_DOC[] =
-    "{ \"version\": \"1.0\", \"steps\": [ { \"action\": { \"name\": \"Restart Services\", \"type\": \"runHandler\", "
-    "\"input\": { \"handler\": \"restart-services.sh\", \"args\": [ \"aws-iot-device-client\" ], \"path\": \"default\" "
-    "}, "
-    "\"runAsUser\": \"root\" } }]}";
 
 class TestJobsFixture : public ::testing::Test
 {
@@ -95,14 +90,6 @@ TEST_F(TestJobsFixture, PrintGreeting)
 {
     string jobId = "Print-Greeting-" + resourceHandler->GetTimeStamp();
     resourceHandler->CreateJob(jobId, RUN_COMMAND_PRINT_GREETING_JOB_DOC);
-
-    ASSERT_EQ(resourceHandler->GetJobExecutionStatusWithRetry(jobId), JobExecutionStatus::SUCCEEDED);
-}
-
-TEST_F(TestJobsFixture, RestartServices)
-{
-    string jobId = "Restart-Services-" + resourceHandler->GetTimeStamp();
-    resourceHandler->CreateJob(jobId, RESTART_SERVICES_JOB_DOC);
 
     ASSERT_EQ(resourceHandler->GetJobExecutionStatusWithRetry(jobId), JobExecutionStatus::SUCCEEDED);
 }

--- a/sample-job-handlers/restart-services.sh
+++ b/sample-job-handlers/restart-services.sh
@@ -11,14 +11,12 @@ echo "Services to restart: $services"
 RESTART_LOCK_FILE=/var/tmp/dc-restart.lock
 LOCK_FILE_PID="0"
 PID=$(pidof aws-iot-device-client)
-
-for service in $services
-do
   # If this script is used to restart Device Client then the Job will not be updated to completed. On restart, the Device
   # Client will begin to execute the Job again. Therefore, to avoid an infinite loop here we need to use a lock file to
   # check if the Device Client had already been restarted.
-  if [ service = "aws-iot-device-client" ];
-  then
+for service in $services
+do
+  if [ "$service" = "aws-iot-device-client" ]; then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       if sudo -u "$user" -n test -f "$RESTART_LOCK_FILE"; then
         LOCK_FILE_PID=$(cat $RESTART_LOCK_FILE)
@@ -29,12 +27,12 @@ do
       fi
     fi
     if [ "$LOCK_FILE_PID" != "0" ]; then
+      rm $RESTART_LOCK_FILE
       if [ "$LOCK_FILE_PID" = "$PID" ]; then
         echo "Failed to restart aws-iot-device-client"
         exit 1;
       else
         echo "Successfully restarted aws-iot-device-client"
-        rm $RESTART_LOCK_FILE
         continue;
       fi
     else

--- a/sample-job-handlers/restart-services.sh
+++ b/sample-job-handlers/restart-services.sh
@@ -14,7 +14,7 @@ PID=$(pidof aws-iot-device-client)
 
 for service in $services
 do
-  if [[ service == 'aws-iot-device-client']];
+  if [ service = "aws-iot-device-client" ];
   then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       if sudo -u "$user" -n test -f "$RESTART_LOCK_FILE"; then
@@ -25,28 +25,28 @@ do
         LOCK_FILE_PID=$(cat $RESTART_LOCK_FILE)
       fi
     fi
-    if [[ "$LOCK_FILE_PID" != "0"]]; then
-      if [[ "$LOCK_FILE_PID" == "$PID" ]]; then
+    if [ "$LOCK_FILE_PID" != "0" ]; then
+      if [ "$LOCK_FILE_PID" = "$PID" ]; then
         echo "Failed to restart aws-iot-device-client"
         exit 1;
       else
         echo "Successfully restarted aws-iot-device-client"
+        rm $RESTART_LOCK_FILE
         continue;
       fi
     else
-      pidof aws-iot-device-client > $RESTART_LOCK_FILE
+      echo $PID > $RESTART_LOCK_FILE
     fi
   fi
-  if command -v "systemctl" > /dev/null;
-  then
+
+  if command -v "systemctl" > /dev/null; then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       sudo -u "$user" -n systemctl restart "$service"
     else
       echo "username or sudo command not found"
       systemctl restart "$service"
     fi
-  elif command -v "service" > /dev/null;
-  then
+  elif command -v "service" > /dev/null; then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       sudo -u "$user" -n service "$service" restart
     else

--- a/sample-job-handlers/restart-services.sh
+++ b/sample-job-handlers/restart-services.sh
@@ -8,29 +8,53 @@ services=$@
 echo "Username: $user"
 echo "Services to restart: $services"
 
-if command -v "systemctl" > /dev/null;
-then
-  for service in $services
-  do
+RESTART_LOCK_FILE=/var/tmp/dc-restart.lock
+LOCK_FILE_PID="0"
+PID=$(pidof aws-iot-device-client)
+
+for service in $services
+do
+  if [[ service == 'aws-iot-device-client']];
+  then
+    if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
+      if sudo -u "$user" -n test -f "$RESTART_LOCK_FILE"; then
+        LOCK_FILE_PID=$(cat $RESTART_LOCK_FILE)
+      fi
+    else
+      if test -f "$RESTART_LOCK_FILE"; then
+        LOCK_FILE_PID=$(cat $RESTART_LOCK_FILE)
+      fi
+    fi
+    if [[ "$LOCK_FILE_PID" != "0"]]; then
+      if [[ "$LOCK_FILE_PID" == "$PID" ]]; then
+        echo "Failed to restart aws-iot-device-client"
+        exit 1;
+      else
+        echo "Successfully restarted aws-iot-device-client"
+        continue;
+      fi
+    else
+      pidof aws-iot-device-client > $RESTART_LOCK_FILE
+    fi
+  fi
+  if command -v "systemctl" > /dev/null;
+  then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       sudo -u "$user" -n systemctl restart "$service"
     else
       echo "username or sudo command not found"
       systemctl restart "$service"
     fi
-  done
-elif command -v "service" > /dev/null;
-then
-  for service in $services
-  do
+  elif command -v "service" > /dev/null;
+  then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then
       sudo -u "$user" -n service "$service" restart
     else
       echo "username or sudo command not found"
       service "$service" restart
     fi
-  done
-else
-  >&2 echo "No suitable package manager found"
-  exit 1
-fi
+  else
+    >&2 echo "No suitable package manager found"
+    exit 1
+  fi
+done

--- a/sample-job-handlers/restart-services.sh
+++ b/sample-job-handlers/restart-services.sh
@@ -14,6 +14,9 @@ PID=$(pidof aws-iot-device-client)
 
 for service in $services
 do
+  # If this script is used to restart Device Client then the Job will not be updated to completed. On restart, the Device
+  # Client will begin to execute the Job again. Therefore, to avoid an infinite loop here we need to use a lock file to
+  # check if the Device Client had already been restarted.
   if [ service = "aws-iot-device-client" ];
   then
     if id "$user" 2>/dev/null && command -v "sudo" > /dev/null; then


### PR DESCRIPTION
### Motivation
Fixing the infinite restart loop for Device Client when the managed template is used to restart the service.
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/365


### Modifications
#### Change summary
Added integration test, added lock file to handler script.


### Testing
Added integration test to handle the reboot case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
