### PR TITLE
Patch for Greengrass Secure Tunneling failure to start

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -315,15 +315,6 @@ int main(int argc, char *argv[])
         LOG_WARN(TAG, "Unable to append current working directory to PATH environment variable.");
     }
 
-    /**
-     * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
-     * In the future, we may want to move other Device Client startup logic into this function.
-     * returns false if an exception is thrown
-     */
-    if (!init(argc, argv))
-    {
-        return 1;
-    }
     features = make_shared<FeatureRegistry>();
 
     LOGM_INFO(TAG, "Now running AWS IoT Device Client version %s", DEVICE_CLIENT_VERSION_FULL);
@@ -354,6 +345,11 @@ int main(int argc, char *argv[])
          * Establish MQTT connection using claim certificates and private key to provision the device/thing.
          */
 #    if !defined(DISABLE_MQTT)
+        /**
+        * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
+        * In the future, we may want to move other Device Client startup logic into this function.
+        * returns false if an exception is thrown
+        */
         if (!init(argc, argv))
         {
             return 1;
@@ -388,6 +384,11 @@ int main(int argc, char *argv[])
      * features.
      */
 #if !defined(DISABLE_MQTT)
+    /**
+    * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
+    * In the future, we may want to move other Device Client startup logic into this function.
+    * returns false if an exception is thrown
+    */
     if (!init(argc, argv))
     {
         return 1;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -346,10 +346,10 @@ int main(int argc, char *argv[])
          */
 #    if !defined(DISABLE_MQTT)
         /**
-        * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
-        * In the future, we may want to move other Device Client startup logic into this function.
-        * returns false if an exception is thrown
-        */
+         * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
+         * In the future, we may want to move other Device Client startup logic into this function.
+         * returns false if an exception is thrown
+         */
         if (!init(argc, argv))
         {
             return 1;
@@ -385,10 +385,10 @@ int main(int argc, char *argv[])
      */
 #if !defined(DISABLE_MQTT)
     /**
-    * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
-    * In the future, we may want to move other Device Client startup logic into this function.
-    * returns false if an exception is thrown
-    */
+     * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
+     * In the future, we may want to move other Device Client startup logic into this function.
+     * returns false if an exception is thrown
+     */
     if (!init(argc, argv))
     {
         return 1;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -354,6 +354,10 @@ int main(int argc, char *argv[])
          * Establish MQTT connection using claim certificates and private key to provision the device/thing.
          */
 #    if !defined(DISABLE_MQTT)
+        if (!init(argc, argv))
+        {
+            return 1;
+        }
         attemptConnection();
 #    endif
 
@@ -384,6 +388,10 @@ int main(int argc, char *argv[])
      * features.
      */
 #if !defined(DISABLE_MQTT)
+    if (!init(argc, argv))
+    {
+        return 1;
+    }
     attemptConnection();
 #endif
 

--- a/source/util/LockFile.cpp
+++ b/source/util/LockFile.cpp
@@ -34,22 +34,18 @@ LockFile::LockFile(const std::string &filedir, const std::string &process, const
             ifstream cmd(processPath.c_str());
             if (cmd && cmd >> cmdline && cmdline.find(basename) != string::npos)
             {
-                LOGM_ERROR(
+                LOGM_WARN(
                     TAG,
                     "Pid %s associated with active process %s in lockfile: %s",
                     Sanitize(storedPid).c_str(),
                     Sanitize(process).c_str(),
                     Sanitize(fullPath).c_str());
-
-                throw runtime_error{"Device Client is already running."};
             }
         }
         // remove stale pid file
         if (remove(fullPath.c_str()))
         {
-            LOGM_ERROR(TAG, "Unable to remove stale lockfile: %s", Sanitize(fullPath).c_str());
-
-            throw runtime_error{"Error removing stale lockfile."};
+            LOGM_WARN(TAG, "Unable to remove stale lockfile: %s", Sanitize(fullPath).c_str());
         }
     }
     fileIn.close();
@@ -57,7 +53,7 @@ LockFile::LockFile(const std::string &filedir, const std::string &process, const
     FILE *file = fopen(fullPath.c_str(), "wx");
     if (!file)
     {
-        LOGM_ERROR(
+        LOGM_WARN(
             TAG, "Unable to open lockfile. File may be in use or does not exist: %s", Sanitize(fullPath).c_str());
     }
     else

--- a/source/util/LockFile.cpp
+++ b/source/util/LockFile.cpp
@@ -45,7 +45,7 @@ LockFile::LockFile(const std::string &filedir, const std::string &process, const
         // remove stale pid file
         if (remove(fullPath.c_str()))
         {
-            LOGM_WARN(TAG, "Unable to remove stale lockfile: %s", Sanitize(fullPath).c_str());
+            LOGM_ERROR(TAG, "Unable to remove stale lockfile: %s", Sanitize(fullPath).c_str());
         }
     }
     fileIn.close();
@@ -53,7 +53,7 @@ LockFile::LockFile(const std::string &filedir, const std::string &process, const
     FILE *file = fopen(fullPath.c_str(), "wx");
     if (!file)
     {
-        LOGM_WARN(
+        LOGM_ERROR(
             TAG, "Unable to open lockfile. File may be in use or does not exist: %s", Sanitize(fullPath).c_str());
     }
     else

--- a/source/util/LockFile.cpp
+++ b/source/util/LockFile.cpp
@@ -34,18 +34,22 @@ LockFile::LockFile(const std::string &filedir, const std::string &process, const
             ifstream cmd(processPath.c_str());
             if (cmd && cmd >> cmdline && cmdline.find(basename) != string::npos)
             {
-                LOGM_WARN(
+                LOGM_ERROR(
                     TAG,
                     "Pid %s associated with active process %s in lockfile: %s",
                     Sanitize(storedPid).c_str(),
                     Sanitize(process).c_str(),
                     Sanitize(fullPath).c_str());
+
+                throw runtime_error{"Device Client is already running."};
             }
         }
         // remove stale pid file
         if (remove(fullPath.c_str()))
         {
             LOGM_ERROR(TAG, "Unable to remove stale lockfile: %s", Sanitize(fullPath).c_str());
+
+            throw runtime_error{"Error removing stale lockfile."};
         }
     }
     fileIn.close();


### PR DESCRIPTION
### Motivation
- Moving the call to lockfile handler to indef, so it works with greengrass securetunneling component and does not enforce single process when MQTT is disabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
