### PR TITLE
Upgrade to CMAKE 3.13

### DIFF
--- a/.github/docker-images/base-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/amazonlinux/Dockerfile
@@ -23,9 +23,9 @@ RUN yum -y update \
 # Install pre-built CMake
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
-    && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \
+RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0.tar.gz -o cmake-3.13.0.tar.gz \
+    && tar -zxvf cmake-3.13.0.tar.gz \
+    && cd cmake-3.13.0 \
     && ./bootstrap \
     && make -j 4 \
     && make install

--- a/.github/docker-images/base-images/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/ubi8/Dockerfile
@@ -25,9 +25,9 @@ RUN yum -y update \
 # Install pre-built CMake
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
-    && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \
+RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0.tar.gz -o cmake-3.13.0.tar.gz \
+    && tar -zxvf cmake-3.13.0.tar.gz \
+    && cd cmake-3.13.0 \
     && ./bootstrap \
     && make \
     && make install

--- a/.github/docker-images/base-images/ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/ubuntu/Dockerfile
@@ -34,9 +34,9 @@ RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
 # Install pre-built CMake
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
-    && tar -zxvf cmake-3.10.0.tar.gz \
-    && cd cmake-3.10.0 \
+RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.13.0.tar.gz -o cmake-3.13.0.tar.gz \
+    && tar -zxvf cmake-3.13.0.tar.gz \
+    && cd cmake-3.13.0 \
     && ./bootstrap \
     && make -j 2 \
     && make install

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
@@ -412,7 +412,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** CMake; version 3.10.0 -- https://cmake.org/
+** CMake; version 3.13.0 -- https://cmake.org/
 CMake - Cross Platform Makefile Generator
 Copyright 2000-2022 Kitware, Inc. and Contributors
 All rights reserved.

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
@@ -378,7 +378,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** CMake; version 3.10.0 -- https://cmake.org/
+** CMake; version 3.13.0 -- https://cmake.org/
 CMake - Cross Platform Makefile Generator
 Copyright 2000-2022 Kitware, Inc. and Contributors
 All rights reserved.


### PR DESCRIPTION
### Motivation
Need to upgrade to CMAKE 3.13 due to some build issues with the integration tests resulting from OS updates

### Modifications
#### Change summary
Updated attribution doc and Cmake version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
