### PR TITLE
Excluded feature validation and file creation if DISABLE_MQTT flag is enabled.

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -276,9 +276,9 @@ bool PlainConfig::LoadFromCliArgs(const CliArgs &cliArgs)
         thingName = cliArgs.at(PlainConfig::CLI_THING_NAME).c_str();
     }
 
-    bool loadFeatureCliArgs = tunneling.LoadFromCliArgs(cliArgs);
+    bool loadFeatureCliArgs = tunneling.LoadFromCliArgs(cliArgs) && logConfig.LoadFromCliArgs(cliArgs);
 #if !defined(DISABLE_MQTT)
-    loadFeatureCliArgs = loadFeatureCliArgs && logConfig.LoadFromCliArgs(cliArgs) && jobs.LoadFromCliArgs(cliArgs) &&
+    loadFeatureCliArgs = loadFeatureCliArgs && jobs.LoadFromCliArgs(cliArgs) &&
                          deviceDefender.LoadFromCliArgs(cliArgs) && fleetProvisioning.LoadFromCliArgs(cliArgs) &&
                          pubSub.LoadFromCliArgs(cliArgs) && sampleShadow.LoadFromCliArgs(cliArgs) &&
                          configShadow.LoadFromCliArgs(cliArgs) && secureElement.LoadFromCliArgs(cliArgs) &&
@@ -320,11 +320,10 @@ bool PlainConfig::LoadFromEnvironment()
         lockFilePath = lockFilePathStr;
     }
 
-    bool loadFeatureEnvironmentVar = tunneling.LoadFromEnvironment();
+    bool loadFeatureEnvironmentVar = tunneling.LoadFromEnvironment() && logConfig.LoadFromEnvironment();
 #if !defined(DISABLE_MQTT)
-    loadFeatureEnvironmentVar = loadFeatureEnvironmentVar && logConfig.LoadFromEnvironment() &&
-                                jobs.LoadFromEnvironment() && deviceDefender.LoadFromEnvironment() &&
-                                fleetProvisioning.LoadFromEnvironment() &&
+    loadFeatureEnvironmentVar = loadFeatureEnvironmentVar && jobs.LoadFromEnvironment() &&
+                                deviceDefender.LoadFromEnvironment() && fleetProvisioning.LoadFromEnvironment() &&
                                 fleetProvisioningRuntimeConfig.LoadFromEnvironment() && pubSub.LoadFromEnvironment() &&
                                 sampleShadow.LoadFromEnvironment() && configShadow.LoadFromEnvironment();
 #endif

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1097,6 +1097,8 @@ TEST_F(ConfigTestFixture, PubSubSampleCli)
     remove(samplesFilePath.c_str());
 }
 
+#if !defined(DISABLE_MQTT)
+// These tests are not applicable if MQTT is disabled.
 TEST_F(ConfigTestFixture, SampleShadowCli)
 {
     string inputFilePath = "/tmp/inputFile";
@@ -1133,16 +1135,14 @@ TEST_F(ConfigTestFixture, SampleShadowCli)
     config.LoadFromCliArgs(cliArgs);
 
     ASSERT_TRUE(config.Validate());
-#if !defined(DISABLE_MQTT)
-    // ST_COMPONENT_MODE does not require any settings besides those for Secure Tunneling
     ASSERT_TRUE(config.sampleShadow.enabled);
     ASSERT_STREQ("shadow-name", config.sampleShadow.shadowName->c_str());
     ASSERT_STREQ(inputFilePath.c_str(), config.sampleShadow.shadowInputFile->c_str());
     ASSERT_STREQ(outputFilePath.c_str(), config.sampleShadow.shadowOutputFile->c_str());
-#endif
     remove(inputFilePath.c_str());
     remove(outputFilePath.c_str());
 }
+#endif
 
 TEST_F(ConfigTestFixture, SensorPublishMinimumConfig)
 {

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -990,11 +990,14 @@ TEST_F(ConfigTestFixture, FleetProvisioningCli)
     config.LoadFromCliArgs(cliArgs);
 
     ASSERT_TRUE(config.Validate());
+#if !defined(DISABLE_MQTT)
+    // ST_COMPONENT_MODE does not require any settings besides those for Secure Tunneling
     ASSERT_TRUE(config.fleetProvisioning.enabled);
     ASSERT_STREQ("cli-template-name", config.fleetProvisioning.templateName->c_str());
     ASSERT_STREQ("{\"SerialNumber\": \"Device-SN\"}", config.fleetProvisioning.templateParameters->c_str());
     ASSERT_STREQ(filePath.c_str(), config.fleetProvisioning.csrFile->c_str());
     ASSERT_STREQ(filePath.c_str(), config.fleetProvisioning.deviceKey->c_str());
+#endif
 }
 
 TEST_F(ConfigTestFixture, DeviceDefenderCli)
@@ -1083,11 +1086,14 @@ TEST_F(ConfigTestFixture, PubSubSampleCli)
     config.LoadFromCliArgs(cliArgs);
 
     ASSERT_TRUE(config.Validate());
+#if !defined(DISABLE_MQTT)
+    // ST_COMPONENT_MODE does not require any settings besides those for Secure Tunneling
     ASSERT_TRUE(config.pubSub.enabled);
     ASSERT_STREQ("publish_topic", config.pubSub.publishTopic->c_str());
     ASSERT_STREQ(samplesFilePath.c_str(), config.pubSub.publishFile->c_str());
     ASSERT_STREQ("subscribe_topic", config.pubSub.subscribeTopic->c_str());
     ASSERT_STREQ(samplesFilePath.c_str(), config.pubSub.subscribeFile->c_str());
+#endif
     remove(samplesFilePath.c_str());
 }
 
@@ -1127,10 +1133,13 @@ TEST_F(ConfigTestFixture, SampleShadowCli)
     config.LoadFromCliArgs(cliArgs);
 
     ASSERT_TRUE(config.Validate());
+#if !defined(DISABLE_MQTT)
+    // ST_COMPONENT_MODE does not require any settings besides those for Secure Tunneling
     ASSERT_TRUE(config.sampleShadow.enabled);
     ASSERT_STREQ("shadow-name", config.sampleShadow.shadowName->c_str());
     ASSERT_STREQ(inputFilePath.c_str(), config.sampleShadow.shadowInputFile->c_str());
     ASSERT_STREQ(outputFilePath.c_str(), config.sampleShadow.shadowOutputFile->c_str());
+#endif
     remove(inputFilePath.c_str());
     remove(outputFilePath.c_str());
 }


### PR DESCRIPTION
Apart from Secure Tunneling feature excluded all other feature validation and file creation when `DISABLE_MQTT` flag is enabled.

### Motivation
When `DISABLE_MQTT` is enabled, only ST feature is built in the binary so it does not make sense to read other feature config and validate it. 

#### Revision diff summary
N/A

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
Manually tested build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
