### PR TITLE
Marking DC directory safe

### DIFF
--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -11,11 +11,13 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+# Marking Device Client directory safe
+execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Check to make sure we have Git info for this package
 execute_process(COMMAND git log --pretty=format:'%h' -n 1
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                OUTPUT_VARIABLE GIT_INFO
-                ERROR_QUIET)
+                OUTPUT_VARIABLE GIT_INFO)
 
 function (load_version_from_file)
     # Git is not available (this is the case if the source is packaged as an archive), get version from file


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
DC artifact was failing to print DC version


### Modifications
#### Change summary
Marked DC directory as safe to call git commands

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
Tested manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
