### PR TITLE
Updated path to config file in aws-iot-device-client.service

### DIFF
--- a/setup/aws-iot-device-client.service
+++ b/setup/aws-iot-device-client.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-Environment="CONF_PATH=/etc/.aws-iot-device-client/aws-iot-device-client.conf"
+Environment="CONF_PATH=/etc/aws-iot-device-client/aws-iot-device-client.conf"
 ExecStart=/sbin/aws-iot-device-client --config-file $CONF_PATH
 
 [Install]


### PR DESCRIPTION
This must have been a typo - can't think why any one would want to hide the configuration in a dot-directory under /etc

### Motivation
Noticed the issue while integrating aws-iot-device-client with a Yocto build

### Modifications
#### Change summary
A minor typo correction that impacts the location of the configuration file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
