### PR TITLE
Updated SDK commit to use the latest SDK code

### DIFF
--- a/.github/docker-images/Dockerfile
+++ b/.github/docker-images/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE} AS deploy
 COPY . /root/aws-iot-device-client
 RUN mkdir -p /root/aws-iot-device-client/build \
     && cd /root/aws-iot-device-client/build \
-    && cmake .. \
+    && cmake -DCMAKE_BUILD_TYPE=Release .. \
     && cmake --build . --target aws-iot-device-client
 
 ENTRYPOINT ["/root/aws-iot-device-client/build/aws-iot-device-client"]

--- a/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
@@ -46,9 +46,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz -o release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.12.0.tar.gz -o release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout ac3ba3774b031dde1b988e698880d6064d53b9d9 \
+    && git checkout 74c8b683ebe5b1cbf484f6acaa281f56aaa63948 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2.0.20230307.0 as base
 
-ARG OPENSSL_VERSION=1.1.1n
+ARG OPENSSL_VERSION=3.0.8
 
 ###############################################################################
 # Install prereqs
@@ -22,7 +22,7 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 ###############################################################################
-# Install OpenSSL 1.1.1
+# Install OpenSSL 3.0.8
 ###############################################################################
 WORKDIR /tmp
 RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \

--- a/.github/docker-images/base-images/device-client/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubi8/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout ac3ba3774b031dde1b988e698880d6064d53b9d9 \
+    && git checkout 74c8b683ebe5b1cbf484f6acaa281f56aaa63948 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/base-images/device-client/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubi8/Dockerfile
@@ -2,7 +2,7 @@
 #https://access.redhat.com/RegistryAuthentication
 FROM registry.access.redhat.com/ubi8/ubi AS base
 
-ARG OPENSSL_VERSION=1.1.1n
+ARG OPENSSL_VERSION=3.0.8
 
 ###############################################################################
 # Install prereqs
@@ -33,7 +33,7 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
     && make install
 
 ###############################################################################
-# Install OpenSSL 1.1.1
+# Install OpenSSL 3.0.8
 ###############################################################################
 WORKDIR /tmp
 RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \

--- a/.github/docker-images/base-images/device-client/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubi8/Dockerfile
@@ -59,9 +59,9 @@ RUN wget https://dist.opendnssec.org/source/softhsm-2.3.0.tar.gz \
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz -o release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.12.0.tar.gz -o release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
@@ -46,9 +46,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://github.com/google/googletest/archive/release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://github.com/google/googletest/archive/release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
@@ -86,7 +86,7 @@ RUN mkdir sdk-cpp-workspace \
     && cd sdk-cpp-workspace \
     && git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git \
     && cd aws-iot-device-sdk-cpp-v2 \
-    && git checkout ac3ba3774b031dde1b988e698880d6064d53b9d9 \
+    && git checkout 74c8b683ebe5b1cbf484f6acaa281f56aaa63948 \
     && git submodule update --init --recursive \
     && cd .. \
     && mkdir aws-iot-device-sdk-cpp-v2-build \

--- a/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG OPENSSL_VERSION=1.1.1n
+ARG OPENSSL_VERSION=3.0.8
 
 ###############################################################################
 # Install prereqs
@@ -20,7 +20,7 @@ RUN apt-get update -qq \
     && apt-get clean
 
 ###############################################################################
-# Install OpenSSL 1.1.1
+# Install OpenSSL 3.0.8
 ###############################################################################
 WORKDIR /tmp
 RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \

--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -22,9 +22,9 @@ RUN wget https://www.zlib.net/zlib-1.3.tar.gz -O /tmp/zlib-1.3.tar.gz && \
 	make install && \
 	cd /home/dependencies
 
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz -O /tmp/boost.tar.gz && \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz -O /tmp/boost.tar.gz && \
 	tar xzvf /tmp/boost.tar.gz && \
-	cd boost_1_79_0 && \
+	cd boost_1_81_0 && \
 	./bootstrap.sh && \
 	./b2 install link=static && \
 	cd /home/dependencies
@@ -39,14 +39,6 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/p
 	make install && \
 	cd /home/dependencies
 
-RUN git clone https://github.com/openssl/openssl.git && \
-	cd openssl && \
-	git checkout OpenSSL_1_1_1-stable && \
-	./config && \
-	make depend && \
-	make all && \
-	cd /home/dependencies
-
 RUN git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git && \
 	cd Catch2 && \
 	mkdir build && \
@@ -58,7 +50,7 @@ RUN git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git && \
 
 RUN git clone https://github.com/aws-samples/aws-iot-securetunneling-localproxy && \
 	cd aws-iot-securetunneling-localproxy && \
-    git checkout 851de4cc2b48861b835327d005000c7d0c81d11b && \
+    git checkout d3150e0ebc4ef022939deb1ab43de005254f5751 && \
 	mkdir build && \
 	cd build && \
 	cmake ../ && \

--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -14,9 +14,9 @@ RUN apt update && apt upgrade -y && \
 RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
-	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
-	cd zlib-1.2.13 && \
+RUN wget https://www.zlib.net/zlib-1.3.tar.gz -O /tmp/zlib-1.3.tar.gz && \
+	tar xzvf /tmp/zlib-1.3.tar.gz && \
+	cd zlib-1.3 && \
 	./configure && \
 	make && \
 	make install && \

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
@@ -377,7 +377,7 @@ Public License instead of this License.
 
 ------
 
-** Google Test 1.10.0; version 1.10.0 -- https://github.com/google/googletest/blob/v1.10.x/LICENSE
+** Google Test 1.12.0; version 1.12.0 -- https://github.com/google/googletest/blob/v1.12.x/LICENSE
 Copyright 2008, Google Inc.
 All rights reserved.
 

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
@@ -343,7 +343,7 @@ Public License instead of this License.
 
 ------
 
-** Google Test 1.10.0; version 1.10.0 -- https://github.com/google/googletest/blob/v1.10.x/LICENSE
+** Google Test 1.12.0; version 1.12.0 -- https://github.com/google/googletest/blob/v1.12.x/LICENSE
 Copyright 2008, Google Inc.
 All rights reserved.
 

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -370,7 +370,7 @@ jobs:
           DEVICE_KEY_SECRET: ${{ secrets.FP_DEVICE_KEY_SECRET }}
           AMAZON_ROOT_CA: ${{ secrets.AMAZON_ROOT_CA }}
         run: |
-          docker run -e AWS_ACCESS_KEY_ID="$(echo ${{ secrets.INTEG_USER_KEY_ID }})" -e AWS_SECRET_ACCESS_KEY="$(echo ${{ secrets.INTEG_USER_KEY_SECRET }})" -e IOT_ENDPOINT="$(echo $IOT_ENDPOINT)" -e CERTIFICATE="$(echo $CERTIFICATE)" -e DEVICE_KEY_SECRET="$(echo $DEVICE_KEY_SECRET)" -e AMAZON_ROOT_CA="$(echo $AMAZON_ROOT_CA)" -e THING_NAME=fleetprovisioning ${{ steps.build-test-runner.outputs.imageid }} --clean-up
+          docker run -e AWS_ACCESS_KEY_ID="$(echo ${{ secrets.INTEG_USER_KEY_ID }})" -e AWS_SECRET_ACCESS_KEY="$(echo ${{ secrets.INTEG_USER_KEY_SECRET }})" -e IOT_ENDPOINT="$(echo $IOT_ENDPOINT)" -e CERTIFICATE="$(echo $CERTIFICATE)" -e DEVICE_KEY_SECRET="$(echo $DEVICE_KEY_SECRET)" -e AMAZON_ROOT_CA="$(echo $AMAZON_ROOT_CA)" -e THING_NAME=fleetprovisioning ${{ steps.build-test-runner.outputs.imageid }} --skip-st --clean-up
   e2e-tests-ubuntu-aarch64:
     runs-on: ubuntu-latest
     if: ${{ false }} # Disabled for now. aarch64 local proxy build takes too long

--- a/CMakeLists.txt.awssdk
+++ b/CMakeLists.txt.awssdk
@@ -5,7 +5,7 @@ project(aws-iot-device-sdk-cpp-v2-download NONE)
 include(ExternalProject)
 ExternalProject_Add(aws-iot-device-sdk-cpp-v2
         GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
-        GIT_TAG                 ac3ba3774b031dde1b988e698880d6064d53b9d9
+        GIT_TAG                 74c8b683ebe5b1cbf484f6acaa281f56aaa63948
         SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
         CONFIGURE_COMMAND       ""

--- a/CMakeLists.txt.gtest
+++ b/CMakeLists.txt.gtest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           release-1.10.0
+        GIT_TAG           release-1.12.0
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CONFIGURE_COMMAND ""

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The AWS IoT Device Client is currently compatible with x86_64, aarch64, armv7l, 
 
 * C++ 11 or higher
 * [CMake](https://cmake.org/) 3.10+
-* OpenSSL 1.1.1
+* OpenSSL 3.0.0+
 * [aws-iot-device-sdk-cpp-v2](https://github.com/aws/aws-iot-device-sdk-cpp-v2) commit hash located in `CMakeLists.txt.awssdk`
 
 *Note:* The TLS stack, and the version of the SDK mentioned above is what our CI uses.  You could potentially use a different TLS stack for example, we just don't actively test or support this.

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,4 +2,4 @@
 # Defaults to ubuntu (18.04). Other options are amazonlinux and ubi8
 os=${1:-"ubuntu"}
 
-docker build . --file .github/docker-images/base-images/"$os"/Dockerfile
+docker build . --file .github/docker-images/base-images/device-client/"$os"/Dockerfile

--- a/integration-tests/CMakeLists.txt.gtest
+++ b/integration-tests/CMakeLists.txt.gtest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           release-1.11.0
+        GIT_TAG           release-1.12.0
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CMAKE_ARGS        -DCMAKE_BUILD_TYPE=Debug

--- a/integration-tests/source/GTestMain.cpp
+++ b/integration-tests/source/GTestMain.cpp
@@ -104,7 +104,7 @@ bool parseCliArgs(int argc, char **argv)
         }
         else if (currentArg == CLI_CLEAN_UP)
         {
-            CLEAN_UP = true;
+            CLEAN_UP = false;
         }
         else
         {

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -543,7 +543,6 @@ void SharedCrtResourceManager::disconnect()
         return;
     }
 
->>>>>>> updateSDKVersion
     if (connection->Disconnect())
     {
         if (connectionClosedPromise.get_future().wait_for(std::chrono::seconds(DEFAULT_WAIT_TIME_SECONDS)) ==

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -346,7 +346,7 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
             TAG,
             "Attempting to establish MQTT connection with proxy: %s:%u",
             proxyOptions.HostName.c_str(),
-            proxyConfig.proxyPort.value());
+            proxyOptions.Port);
 
         if (proxyConfig.httpProxyAuthEnabled)
         {

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -516,6 +516,10 @@ Aws::Crt::Io::ClientBootstrap *SharedCrtResourceManager::getClientBootstrap()
 void SharedCrtResourceManager::disconnect()
 {
     LOG_DEBUG(TAG, "Attempting to disconnect MQTT connection");
+    if (connection == NULL)
+    {
+        return;
+    }
     if (connection->Disconnect())
     {
         if (connectionClosedPromise.get_future().wait_for(std::chrono::seconds(DEFAULT_WAIT_TIME_SECONDS)) ==

--- a/source/SharedCrtResourceManager.cpp
+++ b/source/SharedCrtResourceManager.cpp
@@ -340,11 +340,12 @@ int SharedCrtResourceManager::establishConnection(const PlainConfig &config)
     {
         proxyOptions.HostName = proxyConfig.proxyHost->c_str();
         proxyOptions.Port = proxyConfig.proxyPort.value();
+        proxyOptions.ProxyConnectionType = Aws::Crt::Http::AwsHttpProxyConnectionType::Tunneling;
 
         LOGM_INFO(
             TAG,
             "Attempting to establish MQTT connection with proxy: %s:%u",
-            proxyConfig.proxyHost->c_str(),
+            proxyOptions.HostName.c_str(),
             proxyConfig.proxyPort.value());
 
         if (proxyConfig.httpProxyAuthEnabled)

--- a/source/SharedCrtResourceManager.h
+++ b/source/SharedCrtResourceManager.h
@@ -49,7 +49,7 @@ namespace Aws
 
                 int buildClient(const PlainConfig &config);
 
-                void initializeAllocator(const PlainConfig &config);
+                void loadMemTraceLevelFromEnvironment();
 
               protected:
                 /**
@@ -58,7 +58,7 @@ namespace Aws
                 bool locateCredentials(const PlainConfig &config) const;
 
               public:
-                SharedCrtResourceManager() = default;
+                SharedCrtResourceManager() {}
 
                 virtual ~SharedCrtResourceManager();
 
@@ -79,6 +79,8 @@ namespace Aws
                 static const int ABORT = 2;
 
                 bool initialize(const PlainConfig &config, std::shared_ptr<Util::FeatureRegistry> featureRegistry);
+
+                void initializeAllocator();
 
                 void initializeAWSHttpLib();
 

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -290,24 +290,6 @@ bool PlainConfig::LoadFromCliArgs(const CliArgs &cliArgs)
 
 bool PlainConfig::LoadFromEnvironment()
 {
-    const char *memTraceLevelStr = std::getenv("AWS_CRT_MEMORY_TRACING");
-    if (memTraceLevelStr)
-    {
-        switch (atoi(memTraceLevelStr))
-        {
-            case AWS_MEMTRACE_BYTES:
-                LOG_DEBUG(Config::TAG, "Set AWS_CRT_MEMORY_TRACING=AWS_MEMTRACE_BYTES");
-                memTraceLevel = AWS_MEMTRACE_BYTES;
-                break;
-            case AWS_MEMTRACE_STACKS:
-                LOG_DEBUG(Config::TAG, "Set AWS_CRT_MEMORY_TRACING=AWS_MEMTRACE_STACKS");
-                memTraceLevel = AWS_MEMTRACE_STACKS;
-                break;
-            default:
-                break;
-        }
-    }
-
     const char *lockFilePathIn = std::getenv("LOCK_FILE_PATH");
     if (lockFilePathIn)
     {

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -17,6 +17,7 @@
 
 #endif
 
+#include "../SharedCrtResourceManager.h"
 #include "../util/FileUtils.h"
 #include "../util/MqttUtils.h"
 #include "../util/ProxyUtils.h"
@@ -2641,6 +2642,14 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 
 bool Config::init(const CliArgs &cliArgs)
 {
+#if defined(EXCLUDE_JOBS)
+    config.jobs.enabled = false;
+#endif
+
+#if defined(EXCLUDE_ST)
+    config.tunneling.enabled = false;
+#endif
+
     try
     {
         string filename = Config::DEFAULT_CONFIG_FILE;

--- a/source/config/Config.h
+++ b/source/config/Config.h
@@ -108,7 +108,6 @@ namespace Aws
                 Aws::Crt::Optional<std::string> rootCa;
                 Aws::Crt::Optional<std::string> thingName;
 
-                aws_mem_trace_level memTraceLevel{AWS_MEMTRACE_NONE};
                 std::string lockFilePath{DEFAULT_LOCK_FILE_PATH};
 
                 struct LogConfig : public LoadableFromJsonAndCliAndEnvironment

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -348,6 +348,7 @@ int main(int argc, char *argv[])
     int received_signal;
     sigaddset(&sigset, SIGINT);
     sigaddset(&sigset, SIGHUP);
+    sigaddset(&sigset, SIGTERM);
     sigprocmask(SIG_BLOCK, &sigset, nullptr);
 
     auto listener = std::make_shared<DefaultClientBaseNotifier>();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -237,6 +237,10 @@ namespace Aws
                         case ClientBaseEventNotification::FEATURE_STOPPED:
                         {
                             LOGM_INFO(TAG, "%s has stopped", feature->getName().c_str());
+// Stopping DC instance if secure tunnel is closed for a ST component
+#if defined(DISABLE_MQTT)
+                            shutdown();
+#endif
                             break;
                         }
                         default:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -293,12 +293,17 @@ namespace Aws
 
 int main(int argc, char *argv[])
 {
-    CliArgs cliArgs;
+
     if (Config::CheckTerminalArgs(argc, argv))
     {
         LoggerFactory::getLoggerInstance()->shutdown();
         return 0;
     }
+
+    resourceManager = std::make_shared<SharedCrtResourceManager>();
+    resourceManager->initializeAllocator();
+
+    CliArgs cliArgs;
     if (!Config::ParseCliArgs(argc, argv, cliArgs) || !config.init(cliArgs))
     {
         LOGM_ERROR(
@@ -352,8 +357,6 @@ int main(int argc, char *argv[])
     sigprocmask(SIG_BLOCK, &sigset, nullptr);
 
     auto listener = std::make_shared<DefaultClientBaseNotifier>();
-    resourceManager = std::make_shared<SharedCrtResourceManager>();
-
     if (!resourceManager.get()->initialize(config.config, features))
     {
         LOGM_ERROR(TAG, "*** %s: Failed to initialize AWS CRT SDK.", DC_FATAL_ERROR);

--- a/source/tunneling/SecureTunnelWrapper.cpp
+++ b/source/tunneling/SecureTunnelWrapper.cpp
@@ -58,22 +58,22 @@ SecureTunnelWrapper::SecureTunnelWrapper(
     const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
     const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset)
     : secureTunnel((Aws::Iotsecuretunneling::SecureTunnelBuilder(
-          allocator,
-          *bootstrap,
-          socketOptions,
-          accessToken,
-          localProxyMode,
-          endpoint))
-          .WithHttpClientConnectionProxyOptions(proxyOptions)
-          .WithRootCa(rootCa)
-          .WithOnConnectionComplete(onConnectionComplete)
-          .WithOnConnectionShutdown(onConnectionShutdown)
-          .WithOnSendDataComplete(onSendDataComplete)
-          .WithOnDataReceive(onDataReceive)
-          .WithOnStreamStart(onStreamStart)
-          .WithOnStreamReset(onSessionReset)
-          .WithOnSessionReset(onSessionReset)
-          .Build())
+                        allocator,
+                        *bootstrap,
+                        socketOptions,
+                        accessToken,
+                        localProxyMode,
+                        endpoint))
+                       .WithHttpClientConnectionProxyOptions(proxyOptions)
+                       .WithRootCa(rootCa)
+                       .WithOnConnectionComplete(onConnectionComplete)
+                       .WithOnConnectionShutdown(onConnectionShutdown)
+                       .WithOnSendDataComplete(onSendDataComplete)
+                       .WithOnDataReceive(onDataReceive)
+                       .WithOnStreamStart(onStreamStart)
+                       .WithOnStreamReset(onSessionReset)
+                       .WithOnSessionReset(onSessionReset)
+                       .Build())
 {
 }
 

--- a/source/tunneling/SecureTunnelWrapper.cpp
+++ b/source/tunneling/SecureTunnelWrapper.cpp
@@ -40,6 +40,43 @@ SecureTunnelWrapper::SecureTunnelWrapper(
           onSessionReset))
 {
 }
+
+SecureTunnelWrapper::SecureTunnelWrapper(
+    Aws::Crt::Allocator *allocator,
+    Aws::Crt::Io::ClientBootstrap *bootstrap,
+    const Aws::Crt::Io::SocketOptions &socketOptions,
+    const Aws::Crt::Http::HttpClientConnectionProxyOptions &proxyOptions,
+    const std::string &accessToken,
+    aws_secure_tunneling_local_proxy_mode localProxyMode,
+    const std::string &endpoint,
+    const std::string &rootCa,
+    const Aws::Iotsecuretunneling::OnConnectionComplete &onConnectionComplete,
+    const Aws::Iotsecuretunneling::OnConnectionShutdown &onConnectionShutdown,
+    const Aws::Iotsecuretunneling::OnSendDataComplete &onSendDataComplete,
+    const Aws::Iotsecuretunneling::OnDataReceive &onDataReceive,
+    const Aws::Iotsecuretunneling::OnStreamStart &onStreamStart,
+    const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
+    const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset)
+    : secureTunnel((Aws::Iotsecuretunneling::SecureTunnelBuilder(
+          allocator,
+          *bootstrap,
+          socketOptions,
+          accessToken,
+          localProxyMode,
+          endpoint))
+          .WithHttpClientConnectionProxyOptions(proxyOptions)
+          .WithRootCa(rootCa)
+          .WithOnConnectionComplete(onConnectionComplete)
+          .WithOnConnectionShutdown(onConnectionShutdown)
+          .WithOnSendDataComplete(onSendDataComplete)
+          .WithOnDataReceive(onDataReceive)
+          .WithOnStreamStart(onStreamStart)
+          .WithOnStreamReset(onSessionReset)
+          .WithOnSessionReset(onSessionReset)
+          .Build())
+{
+}
+
 int SecureTunnelWrapper::Connect()
 {
     return secureTunnel->Connect();

--- a/source/tunneling/SecureTunnelWrapper.h
+++ b/source/tunneling/SecureTunnelWrapper.h
@@ -19,10 +19,32 @@ namespace Aws
                   public:
                     SecureTunnelWrapper() = default;
                     virtual ~SecureTunnelWrapper() = default;
+
+                    // Without HTTP Proxy
                     SecureTunnelWrapper(
                         Aws::Crt::Allocator *allocator,
                         Aws::Crt::Io::ClientBootstrap *clientBootstrap,
                         const Aws::Crt::Io::SocketOptions &socketOptions,
+
+                        const std::string &accessToken,
+                        aws_secure_tunneling_local_proxy_mode localProxyMode,
+                        const std::string &endpointHost,
+                        const std::string &rootCa,
+
+                        const Aws::Iotsecuretunneling::OnConnectionComplete &onConnectionComplete,
+                        const Aws::Iotsecuretunneling::OnConnectionShutdown &onConnectionShutdown,
+                        const Aws::Iotsecuretunneling::OnSendDataComplete &onSendDataComplete,
+                        const Aws::Iotsecuretunneling::OnDataReceive &onDataReceive,
+                        const Aws::Iotsecuretunneling::OnStreamStart &onStreamStart,
+                        const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
+                        const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset);
+
+                    // With HTTP Proxy
+                    SecureTunnelWrapper(
+                        Aws::Crt::Allocator *allocator,
+                        Aws::Crt::Io::ClientBootstrap *clientBootstrap,
+                        const Aws::Crt::Io::SocketOptions &socketOptions,
+                        const Aws::Crt::Http::HttpClientConnectionProxyOptions &proxyOptions,
 
                         const std::string &accessToken,
                         aws_secure_tunneling_local_proxy_mode localProxyMode,
@@ -47,7 +69,7 @@ namespace Aws
 
                     virtual bool IsValid();
 
-                    std::unique_ptr<Aws::Iotsecuretunneling::SecureTunnel> secureTunnel;
+                    std::shared_ptr<Aws::Iotsecuretunneling::SecureTunnel> secureTunnel;
 
                   private:
                     /**

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -28,7 +28,7 @@ namespace Aws
                     const int port,
                     const OnConnectionShutdownFn &onConnectionShutdown)
                     : mSharedCrtResourceManager(manager), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
-                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port), isHTTPProxyEnabled(false),
+                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port),
                       mOnConnectionShutdown(onConnectionShutdown)
                 {
                 }
@@ -42,7 +42,7 @@ namespace Aws
                     const int port,
                     const OnConnectionShutdownFn &onConnectionShutdown)
                     : mSharedCrtResourceManager(manager), mProxyOptions(proxyOptions), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
-                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port), isHTTPProxyEnabled(true),
+                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port),
                       mOnConnectionShutdown(onConnectionShutdown)
                 {
                 }
@@ -205,9 +205,7 @@ namespace Aws
                     const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
                     const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset)
                 {
-                    // const Aws::Crt::Http::HttpClientConnectionProxyOptions& proxyOptions = mProxyOptions;
-
-                    if (isHTTPProxyEnabled) {
+                    if (mProxyOptions.HostName.length() > 0) {
                         LOGM_INFO(TAG, "Creating Secure Tunneling with proxy to: %s", mProxyOptions.HostName.c_str());
                         return std::make_shared<SecureTunnelWrapper>(
                             mSharedCrtResourceManager->getAllocator(),

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -28,7 +28,21 @@ namespace Aws
                     const int port,
                     const OnConnectionShutdownFn &onConnectionShutdown)
                     : mSharedCrtResourceManager(manager), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
-                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port),
+                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port), isHTTPProxyEnabled(false),
+                      mOnConnectionShutdown(onConnectionShutdown)
+                {
+                }
+
+                SecureTunnelingContext::SecureTunnelingContext(
+                    shared_ptr<SharedCrtResourceManager> manager,
+                    const Aws::Crt::Http::HttpClientConnectionProxyOptions &proxyOptions,
+                    const Aws::Crt::Optional<std::string> &rootCa,
+                    const string &accessToken,
+                    const string &endpoint,
+                    const int port,
+                    const OnConnectionShutdownFn &onConnectionShutdown)
+                    : mSharedCrtResourceManager(manager), mProxyOptions(proxyOptions), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
+                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port), isHTTPProxyEnabled(true),
                       mOnConnectionShutdown(onConnectionShutdown)
                 {
                 }
@@ -191,21 +205,44 @@ namespace Aws
                     const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
                     const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset)
                 {
-                    return std::make_shared<SecureTunnelWrapper>(
-                        mSharedCrtResourceManager->getAllocator(),
-                        mSharedCrtResourceManager->getClientBootstrap(),
-                        Crt::Io::SocketOptions(),
-                        mAccessToken,
-                        AWS_SECURE_TUNNELING_DESTINATION_MODE,
-                        mEndpoint,
-                        mRootCa,
-                        onConnectionComplete,
-                        onConnectionShutdown,
-                        onSendDataComplete,
-                        onDataReceive,
-                        onStreamStart,
-                        onStreamReset,
-                        onSessionReset);
+                    // const Aws::Crt::Http::HttpClientConnectionProxyOptions& proxyOptions = mProxyOptions;
+
+                    if (isHTTPProxyEnabled) {
+                        LOGM_INFO(TAG, "Creating Secure Tunneling with proxy to: %s", mProxyOptions.HostName.c_str());
+                        return std::make_shared<SecureTunnelWrapper>(
+                            mSharedCrtResourceManager->getAllocator(),
+                            mSharedCrtResourceManager->getClientBootstrap(),
+                            Crt::Io::SocketOptions(),
+                            mProxyOptions,
+                            mAccessToken,
+                            AWS_SECURE_TUNNELING_DESTINATION_MODE,
+                            mEndpoint,
+                            mRootCa,
+                            onConnectionComplete,
+                            nullptr, // TODO: long term fix needed for onConnectionShutdown callback
+                            onSendDataComplete,
+                            onDataReceive,
+                            onStreamStart,
+                            onStreamReset,
+                            onSessionReset);
+                    }
+                    else {
+                        return std::make_shared<SecureTunnelWrapper>(
+                            mSharedCrtResourceManager->getAllocator(),
+                            mSharedCrtResourceManager->getClientBootstrap(),
+                            Crt::Io::SocketOptions(),
+                            mAccessToken,
+                            AWS_SECURE_TUNNELING_DESTINATION_MODE,
+                            mEndpoint,
+                            mRootCa,
+                            onConnectionComplete,
+                            nullptr, // TODO: long term fix needed for onConnectionShutdown callback
+                            onSendDataComplete,
+                            onDataReceive,
+                            onStreamStart,
+                            onStreamReset,
+                            onSessionReset);
+                    }
                 }
 
                 std::shared_ptr<TcpForward> SecureTunnelingContext::CreateTcpForward()

--- a/source/tunneling/SecureTunnelingContext.cpp
+++ b/source/tunneling/SecureTunnelingContext.cpp
@@ -41,9 +41,9 @@ namespace Aws
                     const string &endpoint,
                     const int port,
                     const OnConnectionShutdownFn &onConnectionShutdown)
-                    : mSharedCrtResourceManager(manager), mProxyOptions(proxyOptions), mRootCa(rootCa.has_value() ? rootCa.value() : ""),
-                      mAccessToken(accessToken), mEndpoint(endpoint), mPort(port),
-                      mOnConnectionShutdown(onConnectionShutdown)
+                    : mSharedCrtResourceManager(manager), mProxyOptions(proxyOptions),
+                      mRootCa(rootCa.has_value() ? rootCa.value() : ""), mAccessToken(accessToken), mEndpoint(endpoint),
+                      mPort(port), mOnConnectionShutdown(onConnectionShutdown)
                 {
                 }
 
@@ -205,7 +205,8 @@ namespace Aws
                     const Aws::Iotsecuretunneling::OnStreamReset &onStreamReset,
                     const Aws::Iotsecuretunneling::OnSessionReset &onSessionReset)
                 {
-                    if (mProxyOptions.HostName.length() > 0) {
+                    if (mProxyOptions.HostName.length() > 0)
+                    {
                         LOGM_INFO(TAG, "Creating Secure Tunneling with proxy to: %s", mProxyOptions.HostName.c_str());
                         return std::make_shared<SecureTunnelWrapper>(
                             mSharedCrtResourceManager->getAllocator(),
@@ -224,7 +225,8 @@ namespace Aws
                             onStreamReset,
                             onSessionReset);
                     }
-                    else {
+                    else
+                    {
                         return std::make_shared<SecureTunnelWrapper>(
                             mSharedCrtResourceManager->getAllocator(),
                             mSharedCrtResourceManager->getClientBootstrap(),

--- a/source/tunneling/SecureTunnelingContext.h
+++ b/source/tunneling/SecureTunnelingContext.h
@@ -213,11 +213,6 @@ namespace Aws
                     uint16_t mPort{22};
 
                     /**
-                     * \brief boolean for HTTP proxy enablement
-                     */
-                    bool isHTTPProxyEnabled;
-
-                    /**
                      * \brief Callback when the secure tunnel is shutdown
                      */
                     OnConnectionShutdownFn mOnConnectionShutdown;

--- a/source/tunneling/SecureTunnelingContext.h
+++ b/source/tunneling/SecureTunnelingContext.h
@@ -47,6 +47,15 @@ namespace Aws
                         const int port,
                         const OnConnectionShutdownFn &onConnectionShutdown);
 
+                    SecureTunnelingContext(
+                        std::shared_ptr<SharedCrtResourceManager> manager,
+                        const Aws::Crt::Http::HttpClientConnectionProxyOptions &proxyOptions,
+                        const Aws::Crt::Optional<std::string> &rootCa,
+                        const std::string &accessToken,
+                        const std::string &endpoint,
+                        const int port,
+                        const OnConnectionShutdownFn &onConnectionShutdown);
+
                     /**
                      * \brief Constructor
                      */
@@ -179,6 +188,11 @@ namespace Aws
                     std::shared_ptr<SharedCrtResourceManager> mSharedCrtResourceManager;
 
                     /**
+                     * \brief HTTP proxy strategy and auth config
+                     */
+                    Aws::Crt::Http::HttpClientConnectionProxyOptions mProxyOptions;
+
+                    /**
                      * \brief Path to the Amazon root CA
                      */
                     std::string mRootCa;
@@ -197,6 +211,11 @@ namespace Aws
                      * \brief The local TCP port to connect to
                      */
                     uint16_t mPort{22};
+
+                    /**
+                     * \brief boolean for HTTP proxy enablement
+                     */
+                    bool isHTTPProxyEnabled;
 
                     /**
                      * \brief Callback when the secure tunnel is shutdown

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -134,13 +134,6 @@ namespace Aws
                     if (!config.tunneling.subscribeNotification)
                     {
                         auto context = createContext(*config.tunneling.destinationAccessToken, *config.tunneling.region, static_cast<uint16_t>(config.tunneling.port.value()));
-                        // auto context = unique_ptr<SecureTunnelingContext>(new SecureTunnelingContext(
-                        //     mSharedCrtResourceManager,
-                        //     mRootCa,
-                        //     *config.tunneling.destinationAccessToken,
-                        //     GetEndpoint(*config.tunneling.region),
-                        //     static_cast<uint16_t>(config.tunneling.port.value()),
-                        //     bind(&SecureTunnelingFeature::OnConnectionShutdown, this, placeholders::_1)));
                         mContexts.push_back(std::move(context));
                     }
                 }

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -94,7 +94,6 @@ namespace Aws
 
                 void SecureTunnelingFeature::LoadFromConfig(const PlainConfig &config)
                 {
-                    // Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
                     PlainConfig::HttpProxyConfig proxyConfig = config.httpProxyConfig;
 
                     if (proxyConfig.httpProxyEnabled)
@@ -118,7 +117,8 @@ namespace Aws
                             basicAuthConfig.Username = proxyConfig.proxyUsername->c_str();
                             basicAuthConfig.Password = proxyConfig.proxyPassword->c_str();
                             proxyOptions.ProxyStrategy =
-                                Aws::Crt::Http::HttpProxyStrategy::CreateBasicHttpProxyStrategy(basicAuthConfig, Aws::Crt::g_allocator);
+                                Aws::Crt::Http::HttpProxyStrategy::CreateBasicHttpProxyStrategy(
+                                    basicAuthConfig, Aws::Crt::g_allocator);
                         }
                         else
                         {

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -94,6 +94,38 @@ namespace Aws
 
                 void SecureTunnelingFeature::LoadFromConfig(const PlainConfig &config)
                 {
+                    // Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
+                    PlainConfig::HttpProxyConfig proxyConfig = config.httpProxyConfig;
+
+                    if (proxyConfig.httpProxyEnabled)
+                    {
+                        proxyOptions.HostName = proxyConfig.proxyHost->c_str();
+                        proxyOptions.Port = proxyConfig.proxyPort.value();
+                        proxyOptions.ProxyConnectionType = Aws::Crt::Http::AwsHttpProxyConnectionType::Tunneling;
+
+                        LOGM_INFO(
+                            TAG,
+                            "Attempting to establish tunneling connection with proxy: %s:%u",
+                            proxyOptions.HostName.c_str(),
+                            proxyOptions.Port);
+
+                        if (proxyConfig.httpProxyAuthEnabled)
+                        {
+                            LOG_INFO(TAG, "Proxy Authentication is enabled");
+                            Aws::Crt::Http::HttpProxyStrategyBasicAuthConfig basicAuthConfig;
+                            basicAuthConfig.ConnectionType = Aws::Crt::Http::AwsHttpProxyConnectionType::Tunneling;
+                            proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::Basic;
+                            basicAuthConfig.Username = proxyConfig.proxyUsername->c_str();
+                            basicAuthConfig.Password = proxyConfig.proxyPassword->c_str();
+                            proxyOptions.ProxyStrategy =
+                                Aws::Crt::Http::HttpProxyStrategy::CreateBasicHttpProxyStrategy(basicAuthConfig, Aws::Crt::g_allocator);
+                        }
+                        else
+                        {
+                            LOG_INFO(TAG, "Proxy Authentication is disabled");
+                            proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
+                        }
+                    }
                     mThingName = *config.thingName;
                     mRootCa = config.rootCa;
                     mSubscribeNotification = config.tunneling.subscribeNotification;
@@ -101,13 +133,14 @@ namespace Aws
 
                     if (!config.tunneling.subscribeNotification)
                     {
-                        auto context = unique_ptr<SecureTunnelingContext>(new SecureTunnelingContext(
-                            mSharedCrtResourceManager,
-                            mRootCa,
-                            *config.tunneling.destinationAccessToken,
-                            GetEndpoint(*config.tunneling.region),
-                            static_cast<uint16_t>(config.tunneling.port.value()),
-                            bind(&SecureTunnelingFeature::OnConnectionShutdown, this, placeholders::_1)));
+                        auto context = createContext(*config.tunneling.destinationAccessToken, *config.tunneling.region, static_cast<uint16_t>(config.tunneling.port.value()));
+                        // auto context = unique_ptr<SecureTunnelingContext>(new SecureTunnelingContext(
+                        //     mSharedCrtResourceManager,
+                        //     mRootCa,
+                        //     *config.tunneling.destinationAccessToken,
+                        //     GetEndpoint(*config.tunneling.region),
+                        //     static_cast<uint16_t>(config.tunneling.port.value()),
+                        //     bind(&SecureTunnelingFeature::OnConnectionShutdown, this, placeholders::_1)));
                         mContexts.push_back(std::move(context));
                     }
                 }
@@ -257,6 +290,7 @@ namespace Aws
                 {
                     return std::unique_ptr<SecureTunnelingContext>(new SecureTunnelingContext(
                         mSharedCrtResourceManager,
+                        proxyOptions,
                         mRootCa,
                         accessToken,
                         GetEndpoint(region),

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -133,7 +133,10 @@ namespace Aws
 
                     if (!config.tunneling.subscribeNotification)
                     {
-                        auto context = createContext(*config.tunneling.destinationAccessToken, *config.tunneling.region, static_cast<uint16_t>(config.tunneling.port.value()));
+                        auto context = createContext(
+                            *config.tunneling.destinationAccessToken,
+                            *config.tunneling.region,
+                            static_cast<uint16_t>(config.tunneling.port.value()));
                         mContexts.push_back(std::move(context));
                     }
                 }

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -272,12 +272,15 @@ namespace Aws
                 void SecureTunnelingFeature::OnConnectionShutdown(SecureTunnelingContext *contextToRemove)
                 {
                     LOG_DEBUG(TAG, "SecureTunnelingFeature::OnConnectionShutdown");
-
+#if defined(DISABLE_MQTT)
+                    this->stop();
+#else
                     auto it =
                         find_if(mContexts.begin(), mContexts.end(), [&](const unique_ptr<SecureTunnelingContext> &c) {
                             return c.get() == contextToRemove;
                         });
                     mContexts.erase(std::remove(mContexts.begin(), mContexts.end(), *it));
+#endif
                 }
 
             } // namespace SecureTunneling

--- a/source/tunneling/SecureTunnelingFeature.h
+++ b/source/tunneling/SecureTunnelingFeature.h
@@ -9,6 +9,7 @@
 #include "../SharedCrtResourceManager.h"
 #include "IotSecureTunnelingClientWrapper.h"
 #include "SecureTunnelingContext.h"
+#include "aws/crt/http/HttpProxyStrategy.h"
 #include <aws/iotdevicecommon/IotDevice.h>
 #include <aws/iotsecuretunneling/SecureTunnelingNotifyResponse.h>
 
@@ -176,6 +177,11 @@ namespace Aws
                      * attention
                      */
                     std::shared_ptr<ClientBaseNotifier> mClientBaseNotifier;
+
+                    /**
+                     * \brief HTTP proxy strategy and auth config
+                     */
+                    Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
 
                     /**
                      * \brief The ThingName to use

--- a/source/util/MqttUtils.cpp
+++ b/source/util/MqttUtils.cpp
@@ -24,17 +24,6 @@ bool MqttUtils::ValidateAwsIotMqttTopicName(std::string topic)
         topic = reserved_topic.suffix();
     }
 
-    const std::size_t count_slashes = std::count(topic.cbegin(), topic.cend(), '/');
-    if (count_slashes > MAX_NUMBER_OF_FORWARD_SLASHES)
-    {
-        LOGM_ERROR(
-            TAG,
-            "Number of forward slashes in topic (%lu) exceeds maximum (%lu)",
-            count_slashes,
-            MAX_NUMBER_OF_FORWARD_SLASHES);
-        return false;
-    }
-
     // Since std::string is based on char, the size of the string and number of UTF8 chars is same.
     if (topic.size() > MAX_LENGTH_OF_TOPIC)
     {

--- a/source/util/MqttUtils.h
+++ b/source/util/MqttUtils.h
@@ -18,15 +18,10 @@ namespace Aws
                     //
                     // https://docs.aws.amazon.com/general/latest/gr/iot-core.html#message-broker-limits
                     //
-                    // A topic in a publish or subscribe request can have no more than 7 forward slashes (/).
-                    // This excludes the first 3 slashes in the mandatory segments for
-                    // Basic Ingest topics ($AWS/rules/rule-name/).
-                    //
                     // The topic passed to AWS IoT Core when sending a publish request can be no larger
                     // than 256 bytes of UTF-8 encoded characters. This excludes the first 3 mandatory
                     // segments for Basic Ingest topics ($AWS/rules/rule-name/).
                     //
-                    static constexpr std::size_t MAX_NUMBER_OF_FORWARD_SLASHES{7};
                     static constexpr std::size_t MAX_LENGTH_OF_TOPIC{256};
 
                     /**

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1310,41 +1310,6 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
     ASSERT_FALSE(settings.enabled);
 }
 
-TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
-{
-    constexpr char jsonString[] = R"(
-{
-    "endpoint": "endpoint value",
-    "cert": "/tmp/aws-iot-device-client-test-file",
-    "root-ca": "/tmp/aws-iot-device-client-test/AmazonRootCA1.pem",
-    "key": "/tmp/aws-iot-device-client-test-file",
-    "thing-name": "thing-name value",
-    "sensor-publish": {
-        "sensors": [
-            {
-                "addr": "/tmp/sensors/my-sensor-server",
-                "eom_delimiter": "[\r\n]+",
-                "mqtt_topic": "////////my-sensor-data"
-            }
-        ]
-    }
-})";
-    JsonObject jsonObject(jsonString);
-    JsonView jsonView = jsonObject.View();
-
-    PlainConfig config;
-    config.LoadFromJson(jsonView);
-
-#if defined(EXCLUDE_SENSOR_PUBLISH)
-    GTEST_SKIP();
-#endif
-    ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
-    ASSERT_TRUE(config.sensorPublish.enabled);
-    ASSERT_EQ(config.sensorPublish.settings.size(), 1);
-    const auto &settings = config.sensorPublish.settings[0];
-    ASSERT_FALSE(settings.enabled);
-}
-
 TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
 {
     constexpr char jsonString[] = R"(

--- a/test/devicedefender/TestDeviceDefender.cpp
+++ b/test/devicedefender/TestDeviceDefender.cpp
@@ -85,6 +85,9 @@ class TestDeviceDefender : public testing::Test
     {
         deviceDefender = unique_ptr<MockDDFeature>(new MockDDFeature());
         manager = shared_ptr<SharedCrtResourceManager>(new SharedCrtResourceManager());
+        // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+        manager->initializeAllocator();
+
         notifier = shared_ptr<MockNotifier>(new MockNotifier());
         task = shared_ptr<MockReportTask>(new MockReportTask());
         config = getSimpleDDConfig();

--- a/test/fleetprovisioning/TestFleetProvisioning.cpp
+++ b/test/fleetprovisioning/TestFleetProvisioning.cpp
@@ -11,6 +11,7 @@ using namespace Aws::Iot::DeviceClient::FleetProvisioningNS;
 
 TEST(FleetProvisioning, EmptyTemplateParameters)
 {
+    Aws::Iot::DeviceClient::SharedCrtResourceManager resourceManager;
     Aws::Crt::Optional<std::string> params; // start with empty value
     FleetProvisioning fp;
     ASSERT_TRUE(fp.MapParameters(params));
@@ -19,6 +20,10 @@ TEST(FleetProvisioning, EmptyTemplateParameters)
 
 TEST(FleetProvisioning, MalformedTemplateParameters)
 {
+    Aws::Iot::DeviceClient::SharedCrtResourceManager resourceManager;
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    resourceManager.initializeAllocator();
+
     Aws::Crt::Optional<std::string> params("{\"SerialNumber\" \"Device-SN\"}"); // test missing colon
     FleetProvisioning fp;
     ASSERT_FALSE(fp.MapParameters(params));
@@ -30,6 +35,10 @@ TEST(FleetProvisioning, MalformedTemplateParameters)
 
 TEST(FleetProvisioning, ValidTemplateParameters)
 {
+    Aws::Iot::DeviceClient::SharedCrtResourceManager resourceManager;
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    resourceManager.initializeAllocator();
+
     Aws::Crt::Optional<std::string> params("{\"SerialNumber\": \"Device-SN\"}"); // test single JSON property
     FleetProvisioning fp;
     ASSERT_TRUE(fp.MapParameters(params));

--- a/test/jobs/TestJobDocument.cpp
+++ b/test/jobs/TestJobDocument.cpp
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../../source/SharedCrtResourceManager.h"
 #include "../../source/jobs/JobDocument.h"
 #include "../../source/util/UniqueString.h"
+
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <aws/crt/JsonObject.h>
@@ -170,6 +172,10 @@ TEST(JobDocument, SampleJobDocument)
         }
     }
 })";
+
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
 
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
@@ -376,6 +382,10 @@ TEST(JobDocument, MissingRequiredFields)
     }
     })";
 
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
 
@@ -428,6 +438,10 @@ TEST(JobDocument, MinimumJobDocument)
         }
     ]
 })";
+
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
 
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
@@ -522,6 +536,10 @@ TEST(JobDocument, MissingRequiredFieldsValue)
     }
     })";
 
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
 
@@ -548,6 +566,10 @@ TEST(JobDocument, CommandFieldsIsEmpty)
         }
     ]
 })";
+
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
 
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
@@ -576,6 +598,10 @@ TEST(JobDocument, CommandContainsSpaceCharacters)
     ]
 })";
 
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
 
@@ -603,6 +629,10 @@ TEST(JobDocument, SpaceCharactersContainedWithinFirstWordOfCommand)
     ]
 })";
 
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
 
@@ -620,6 +650,10 @@ TEST(JobDocument, oldJobDocumentCompatibility)
     "args": ["https://github.com/awslabs/aws-iot-device-client/archive/refs/tags/v1.3.tar.gz", "/tmp/Downloaded_File.tar.gz"],
     "path": "default"
 })";
+
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
 
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();

--- a/test/jobs/TestJobsFeature.cpp
+++ b/test/jobs/TestJobsFeature.cpp
@@ -258,6 +258,9 @@ class TestJobsFeature : public ::testing::Test
   public:
     void SetUp()
     {
+        // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+        resourceManager.initializeAllocator();
+
         ThingName = Aws::Crt::String("thing-name value");
         notifier = shared_ptr<MockNotifier>(new MockNotifier());
         config = getSimpleConfig();
@@ -269,6 +272,7 @@ class TestJobsFeature : public ::testing::Test
     }
     Aws::Crt::String ThingName;
     shared_ptr<MockNotifier> notifier;
+    SharedCrtResourceManager resourceManager;
     PlainConfig config;
     unique_ptr<StartNextJobExecutionResponse> startNextJobExecutionResponse;
     unique_ptr<MockJobsFeature> jobsMock;

--- a/test/shadow/TestConfigShadowFeature.cpp
+++ b/test/shadow/TestConfigShadowFeature.cpp
@@ -59,6 +59,10 @@ TEST(ConfigShadowFeature, resetClientConfigWithValidJSON)
       }
 })";
 
+    SharedCrtResourceManager resourceManager;
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    resourceManager.initializeAllocator();
+
     JsonObject oldJsonObject(oldJsonString);
     JsonView jsonView = oldJsonObject.View();
     PlainConfig config;
@@ -149,6 +153,9 @@ TEST(ConfigShadowFeature, resetClientConfigWithInvalidJSON)
         "shadow-output-file": ""
       }
 })";
+    SharedCrtResourceManager resourceManager;
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    resourceManager.initializeAllocator();
 
     JsonObject oldJsonObject(oldJsonString);
     JsonView jsonView = oldJsonObject.View();

--- a/test/tunneling/TestSecureTunnelingFeature.cpp
+++ b/test/tunneling/TestSecureTunnelingFeature.cpp
@@ -103,9 +103,12 @@ class TestSecureTunnelingFeature : public testing::Test
   public:
     void SetUp() override
     {
+        manager = shared_ptr<SharedCrtResourceManager>(new SharedCrtResourceManager());
+        // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+        manager->initializeAllocator();
+
         thingName = Aws::Crt::String("thing-name value");
         secureTunnelingFeature = shared_ptr<MockSecureTunnelingFeature>(new MockSecureTunnelingFeature());
-        manager = shared_ptr<SharedCrtResourceManager>(new SharedCrtResourceManager());
         mockClient = shared_ptr<MockIotSecureTunnelingClient>(new MockIotSecureTunnelingClient());
         notifier = shared_ptr<MockNotifier>(new MockNotifier());
         fakeContext = unique_ptr<FakeSecureTunnelContext>(new FakeSecureTunnelContext());

--- a/test/util/TestMqttUtils.cpp
+++ b/test/util/TestMqttUtils.cpp
@@ -27,21 +27,6 @@ TEST(MqttUtils, ReservedTopicValid)
     ASSERT_TRUE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
 }
 
-TEST(MqttUtils, TopicNotValidExceedsMaxSlashes)
-{
-    std::string topic(MqttUtils::MAX_NUMBER_OF_FORWARD_SLASHES + 1, '/');
-
-    ASSERT_FALSE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
-}
-
-TEST(MqttUtils, TopicValidExceedsMaxSlashesWithReservedTopic)
-{
-    std::string topic(RESERVED_TOPIC);
-    std::fill_n(std::back_inserter(topic), MqttUtils::MAX_NUMBER_OF_FORWARD_SLASHES, '/');
-
-    ASSERT_TRUE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
-}
-
 TEST(MqttUtils, TopicNotValidExceedsMaxLength)
 {
     std::string topic(MqttUtils::MAX_LENGTH_OF_TOPIC + 1, 'A');

--- a/test/util/TestSharedResourceManager.cpp
+++ b/test/util/TestSharedResourceManager.cpp
@@ -57,6 +57,9 @@ class SharedResourceManagerTest : public ::testing::Test
 
     void SetUp() override
     {
+        // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+        manager.initializeAllocator();
+
         // SharedCrtResourceManager::locateCredentials will check that cert, key files
         // have valid permissions. Create a temporary file to use as a placeholder for this purpose.
         FileUtils::CreateDirectoryWithPermissions(certDir.c_str(), 0700);

--- a/test/util/TestStringUtils.cpp
+++ b/test/util/TestStringUtils.cpp
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../../source/SharedCrtResourceManager.h"
 #include "../../source/config/Config.h"
 #include "../../source/util/StringUtils.h"
+
 #include "gtest/gtest.h"
 #include <aws/crt/JsonObject.h>
 
@@ -65,6 +67,10 @@ TEST(StringUtils, leavesNewLineAndTabAlone)
 
 TEST(StringUtils, maptoString)
 {
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> map;
     map.insert(std::pair<Aws::Crt::String, Aws::Crt::String>("a", "b"));
     map.insert(std::pair<Aws::Crt::String, Aws::Crt::String>("c", "d"));
@@ -130,6 +136,10 @@ TEST(StringUtils, ParseToStringVector)
 {
     "args": ["hello", "world"]
 })";
+    // Initializing allocator, so we can use CJSON lib from SDK in our unit tests.
+    SharedCrtResourceManager resourceManager;
+    resourceManager.initializeAllocator();
+
     JsonObject jsonObject(jsonString);
     JsonView jsonView = jsonObject.View();
 


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: #411 


### Modifications
#### Change summary
* Updated SDK commit to use the latest SDK code.
* Updated resource manager `initializeAllocator` method to public so it can be called from outside of `SharedCrtResourceManager`. 
* Added null check in `SharedCrtResourceManager::disconnect` method. 
* Updated unit test code to initialize allocator before using CRT library methods like CJSON or Crt::Map.
* Reverted this change to avoid calling `init` twice when FP is enabled. https://github.com/awslabs/aws-iot-device-client/pull/391/files

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.
* Addressed reviewers comments 
* Added null check in `SharedCrtResourceManager::disconnect` method. 
* Updated unit test code to initialize allocator before using CRT library methods like CJSON or Crt::Map.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- Manually tested changes locally 
- Ran CI tests 
- Ran Unit tests locally. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
