### PR TITLE
Removed DC initialization code which creates multiple lock files.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -321,6 +321,19 @@ int main(int argc, char *argv[])
         LOG_WARN(TAG, "Unable to append current working directory to PATH environment variable.");
     }
 
+#if !defined(DISABLE_MQTT)
+    /**
+     * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
+     * In the future, we may want to move other Device Client startup logic into this function.
+     * returns false if an exception is thrown
+     */
+    if (!init(argc, argv))
+    {
+        LOGM_ERROR(TAG, "*** %s: An instance of Device Client is already running.", DC_FATAL_ERROR);
+        deviceClientAbort("An instance of Device Client is already running.");
+    }
+#endif
+    
     features = make_shared<FeatureRegistry>();
 
     LOGM_INFO(TAG, "Now running AWS IoT Device Client version %s", DEVICE_CLIENT_VERSION_FULL);
@@ -346,16 +359,6 @@ int main(int argc, char *argv[])
     if (config.config.fleetProvisioning.enabled &&
         !config.config.fleetProvisioningRuntimeConfig.completedFleetProvisioning)
     {
-        /**
-         * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
-         * In the future, we may want to move other Device Client startup logic into this function.
-         * returns false if an exception is thrown
-         */
-        if (!init(argc, argv))
-        {
-            LOGM_ERROR(TAG, "*** %s: An instance of Device Client is already running.", DC_FATAL_ERROR);
-            deviceClientAbort("An instance of Device Client is already running.");
-        }
         /*
          * Establish MQTT connection using claim certificates and private key to provision the device/thing.
          */
@@ -394,16 +397,6 @@ int main(int argc, char *argv[])
 #endif
 
 #if !defined(DISABLE_MQTT)
-    /**
-     * init() is currently responsible for making sure only 1 instance of Device Client is running at a given time.
-     * In the future, we may want to move other Device Client startup logic into this function.
-     * returns false if an exception is thrown
-     */
-    if (!init(argc, argv))
-    {
-        LOGM_ERROR(TAG, "*** %s: An instance of Device Client is already running.", DC_FATAL_ERROR);
-        deviceClientAbort("An instance of Device Client is already running.");
-    }
     /*
      * Establish MQTT connection using permanent certificate and private key to start and run AWS IoT Device Client
      * features.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
         deviceClientAbort("An instance of Device Client is already running.");
     }
 #endif
-    
+
     features = make_shared<FeatureRegistry>();
 
     LOGM_INFO(TAG, "Now running AWS IoT Device Client version %s", DEVICE_CLIENT_VERSION_FULL);


### PR DESCRIPTION
### Motivation
- Issue number: #418 


### Modifications
#### Change summary
Device Client uses a lock files for making sure only 1 instance of Device Client is running at a given time. With Fleet Provisioning feature enabled, DC was accidentally creating multiple lock files which was resulting in DC abort. By updating the logic, DC will now only create one lock file as expected.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
