### PR TITLE
Fix docker-build.sh

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,4 +2,4 @@
 # Defaults to ubuntu (18.04). Other options are amazonlinux and ubi8
 os=${1:-"ubuntu"}
 
-docker build . --file .github/docker-images/base-images/"$os"/Dockerfile
+docker build . --file .github/docker-images/base-images/device-client/"$os"/Dockerfile


### PR DESCRIPTION
### Motivation
There is an additional level of indirection required for the script to be able to build the container. Otherwise the container build fails.
- Issue number: not created


### Modifications
#### Change summary
Added the exact reference to the folder where the Dockerfile lives

### Testing
Tested on Ubuntu. Waiting for CI/CD to feed back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
