### PR TITLE
Compile device client binaries as Release build type

### DIFF
--- a/.github/docker-images/Dockerfile
+++ b/.github/docker-images/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE} AS deploy
 COPY . /root/aws-iot-device-client
 RUN mkdir -p /root/aws-iot-device-client/build \
     && cd /root/aws-iot-device-client/build \
-    && cmake .. \
+    && cmake -DCMAKE_BUILD_TYPE=Release .. \
     && cmake --build . --target aws-iot-device-client
 
 ENTRYPOINT ["/root/aws-iot-device-client/build/aws-iot-device-client"]


### PR DESCRIPTION
### Motivation
- The device client binary we publish to public ecr is using a `Debug` build which results in a binary size of 32M in comparison to the `Release` build which produces a binary of 6M. 

### Modifications
#### Change summary
Modify the release type of the device client builds used in Dockerfile from `Debug` to `Relase`

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
32M binary compiled using `Debug` — `cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . --target aws-iot-device-client`
```
root@6a67a591380f:/src/build-release# ls -lh aws-iot-device-client 
-rwxr-xr-x 1 root root 32M Aug  2 01:08 aws-iot-device-client
root@6a67a591380f:/src/build-release# ./aws-iot-device-client --version
v1.8.27-a0d1cf4
```

6M binary compiled using `Release` — `cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Release .. && cmake --build . --target aws-iot-device-client`
```
root@1c3cee53a3c8:/src/build-release# ls -lh ./aws-iot-device-client 
-rwxr-xr-x 1 root root 6.4M Aug  2 22:15 ./aws-iot-device-client
root@1c3cee53a3c8:/src/build-release# ./aws-iot-device-client --version
v1.8.27-a0d1cf4
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
