### PR TITLE
Updated code to shutdown on tunnel close callback

### DIFF
--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /home/dependencies
 
 RUN wget https://www.zlib.net/zlib-1.3.tar.gz -O /tmp/zlib-1.3.tar.gz && \
 	tar xzvf /tmp/zlib-1.3.tar.gz && \
-	cd zlib-1.2.13 && \
+	cd zlib-1.3 && \
 	./configure && \
 	make && \
 	make install && \

--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && apt upgrade -y && \
 RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://www.zlib.net/zlib-1.3.tar.gz -O /tmp/zlib-1.3.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \

--- a/.github/docker-images/integration-tests/ubuntu/Dockerfile
+++ b/.github/docker-images/integration-tests/ubuntu/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
 RUN wget https://www.zlib.net/zlib-1.3.tar.gz -O /tmp/zlib-1.3.tar.gz && \
-	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
+	tar xzvf /tmp/zlib-1.3.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \
 	make && \

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -180,8 +180,7 @@ void attemptConnection()
     try
     {
         Retry::ExponentialRetryConfig retryConfig = {10 * 1000, 900 * 1000, -1, nullptr};
-        auto publishLambda = []() -> bool
-        {
+        auto publishLambda = []() -> bool {
             int connectionStatus = resourceManager.get()->establishConnection(config.config);
             if (SharedCrtResourceManager::ABORT == connectionStatus)
             {
@@ -203,8 +202,8 @@ void attemptConnection()
                 return false;
             }
         };
-        std::thread attemptConnectionThread([retryConfig, publishLambda]
-                                            { Retry::exponentialBackoff(retryConfig, publishLambda); });
+        std::thread attemptConnectionThread(
+            [retryConfig, publishLambda] { Retry::exponentialBackoff(retryConfig, publishLambda); });
         attemptConnectionThread.join();
     }
     catch (const std::exception &e)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -237,6 +237,10 @@ namespace Aws
                         case ClientBaseEventNotification::FEATURE_STOPPED:
                         {
                             LOGM_INFO(TAG, "%s has stopped", feature->getName().c_str());
+                            // Stopping DC for ST component
+                            #if defined(DISABLE_MQTT)
+                            shutdown();
+                            #endif
                             break;
                         }
                         default:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -180,7 +180,8 @@ void attemptConnection()
     try
     {
         Retry::ExponentialRetryConfig retryConfig = {10 * 1000, 900 * 1000, -1, nullptr};
-        auto publishLambda = []() -> bool {
+        auto publishLambda = []() -> bool
+        {
             int connectionStatus = resourceManager.get()->establishConnection(config.config);
             if (SharedCrtResourceManager::ABORT == connectionStatus)
             {
@@ -202,8 +203,8 @@ void attemptConnection()
                 return false;
             }
         };
-        std::thread attemptConnectionThread(
-            [retryConfig, publishLambda] { Retry::exponentialBackoff(retryConfig, publishLambda); });
+        std::thread attemptConnectionThread([retryConfig, publishLambda]
+                                            { Retry::exponentialBackoff(retryConfig, publishLambda); });
         attemptConnectionThread.join();
     }
     catch (const std::exception &e)
@@ -237,10 +238,10 @@ namespace Aws
                         case ClientBaseEventNotification::FEATURE_STOPPED:
                         {
                             LOGM_INFO(TAG, "%s has stopped", feature->getName().c_str());
-                            // Stopping DC for ST component
-                            #if defined(DISABLE_MQTT)
+// Stopping DC for ST component
+#if defined(DISABLE_MQTT)
                             shutdown();
-                            #endif
+#endif
                             break;
                         }
                         default:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -237,7 +237,7 @@ namespace Aws
                         case ClientBaseEventNotification::FEATURE_STOPPED:
                         {
                             LOGM_INFO(TAG, "%s has stopped", feature->getName().c_str());
-// Stopping DC for ST component
+// Stopping DC instance if secure tunnel is closed for a ST component
 #if defined(DISABLE_MQTT)
                             shutdown();
 #endif

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -275,10 +275,10 @@ namespace Aws
 #if defined(DISABLE_MQTT)
                     this->stop();
 #else
-                    auto it = find_if(
-                        mContexts.begin(),
-                        mContexts.end(),
-                        [&](const unique_ptr<SecureTunnelingContext> &c) { return c.get() == contextToRemove; });
+                    auto it =
+                        find_if(mContexts.begin(), mContexts.end(), [&](const unique_ptr<SecureTunnelingContext> &c) {
+                            return c.get() == contextToRemove;
+                        });
                     mContexts.erase(std::remove(mContexts.begin(), mContexts.end(), *it));
 #endif
                 }

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -272,12 +272,15 @@ namespace Aws
                 void SecureTunnelingFeature::OnConnectionShutdown(SecureTunnelingContext *contextToRemove)
                 {
                     LOG_DEBUG(TAG, "SecureTunnelingFeature::OnConnectionShutdown");
-
+                    #if defined(DISABLE_MQTT)
+                    this->stop();
+                    #else
                     auto it =
                         find_if(mContexts.begin(), mContexts.end(), [&](const unique_ptr<SecureTunnelingContext> &c) {
                             return c.get() == contextToRemove;
                         });
                     mContexts.erase(std::remove(mContexts.begin(), mContexts.end(), *it));
+                    #endif
                 }
 
             } // namespace SecureTunneling

--- a/source/tunneling/SecureTunnelingFeature.cpp
+++ b/source/tunneling/SecureTunnelingFeature.cpp
@@ -272,15 +272,15 @@ namespace Aws
                 void SecureTunnelingFeature::OnConnectionShutdown(SecureTunnelingContext *contextToRemove)
                 {
                     LOG_DEBUG(TAG, "SecureTunnelingFeature::OnConnectionShutdown");
-                    #if defined(DISABLE_MQTT)
+#if defined(DISABLE_MQTT)
                     this->stop();
-                    #else
-                    auto it =
-                        find_if(mContexts.begin(), mContexts.end(), [&](const unique_ptr<SecureTunnelingContext> &c) {
-                            return c.get() == contextToRemove;
-                        });
+#else
+                    auto it = find_if(
+                        mContexts.begin(),
+                        mContexts.end(),
+                        [&](const unique_ptr<SecureTunnelingContext> &c) { return c.get() == contextToRemove; });
                     mContexts.erase(std::remove(mContexts.begin(), mContexts.end(), *it));
-                    #endif
+#endif
                 }
 
             } // namespace SecureTunneling


### PR DESCRIPTION
### Motivation
- Greengrass Secure Tunneling component which use Device Client code was not closing the thread on getting the tunnel close notification.

### Modifications
#### Change summary
- Updated code to shutdown Device Client on tunnel close callback

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- Locally tested the changes does not affect the device client application logic


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
