### PR TITLE
Updated Secure Tunneling close logic for Secure Tunneling Component

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -157,7 +157,6 @@ void shutdown()
     }
 #endif
     LoggerFactory::getLoggerInstance()->shutdown();
-    cout << "AWS IoT Device Client must abort execution, reason: ST shutdown";
     exit(EXIT_SUCCESS);
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -145,16 +145,20 @@ void shutdown()
         LOG_DEBUG(TAG, "Calling stop all");
         features->stopAll();
     }
-    resourceManager->dumpMemTrace();
 
     LOG_INFO(TAG, "All features have stopped");
 // terminate program
 #if !defined(DISABLE_MQTT)
-    resourceManager->disconnect();
+    if (resourceManager != NULL)
+    {
+        resourceManager->dumpMemTrace();
+        resourceManager->disconnect();
+        resourceManager.reset();
+    }
 #endif
-    LoggerFactory::getLoggerInstance().get()->shutdown();
-    resourceManager.reset();
-    exit(0);
+    LoggerFactory::getLoggerInstance()->shutdown();
+    cout << "AWS IoT Device Client must abort execution, reason: ST shutdown";
+    exit(EXIT_SUCCESS);
 }
 
 /**
@@ -162,7 +166,7 @@ void shutdown()
  *
  * @param reason the reason why the abort is happening
  */
-void deviceClientAbort(const string &reason)
+void deviceClientAbort(const string &reason, int exitCode)
 {
     if (resourceManager != NULL)
     {
@@ -172,7 +176,7 @@ void deviceClientAbort(const string &reason)
     LoggerFactory::getLoggerInstance()->shutdown();
     cout << "AWS IoT Device Client must abort execution, reason: " << reason << endl;
     cout << "Please check the AWS IoT Device Client logs for more information" << endl;
-    exit(EXIT_FAILURE);
+    exit(exitCode);
 }
 
 void attemptConnection()
@@ -190,7 +194,8 @@ void attemptConnection()
                     "IoT credentials, "
                     "configuration and/or certificate policy. ***",
                     DC_FATAL_ERROR);
-                deviceClientAbort("Failed to establish MQTT connection due to credential/configuration error");
+                deviceClientAbort(
+                    "Failed to establish MQTT connection due to credential/configuration error", EXIT_FAILURE);
                 return true;
             }
             else if (SharedCrtResourceManager::SUCCESS == connectionStatus)
@@ -209,7 +214,7 @@ void attemptConnection()
     catch (const std::exception &e)
     {
         LOGM_ERROR(TAG, "Error attempting to connect: %s", e.what());
-        deviceClientAbort("Failure from attemptConnection");
+        deviceClientAbort("Failure from attemptConnection", EXIT_FAILURE);
     }
 }
 
@@ -237,10 +242,6 @@ namespace Aws
                         case ClientBaseEventNotification::FEATURE_STOPPED:
                         {
                             LOGM_INFO(TAG, "%s has stopped", feature->getName().c_str());
-// Stopping DC instance if secure tunnel is closed for a ST component
-#if defined(DISABLE_MQTT)
-                            shutdown();
-#endif
                             break;
                         }
                         default:
@@ -283,7 +284,7 @@ namespace Aws
                         TAG,
                         "*** %s: Aborting program due to unrecoverable feature error! ***",
                         DeviceClient::DC_FATAL_ERROR);
-                    deviceClientAbort(feature->getName() + " encountered an error");
+                    deviceClientAbort(feature->getName() + " encountered an error", EXIT_FAILURE);
 #endif
                 }
             };
@@ -305,7 +306,7 @@ int main(int argc, char *argv[])
             TAG,
             "*** %s: AWS IoT Device Client must abort execution, reason: Invalid configuration ***",
             DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration");
+        deviceClientAbort("Invalid configuration", EXIT_FAILURE);
     }
 
     if (!LoggerFactory::reconfigure(config.config) &&
@@ -334,7 +335,7 @@ int main(int argc, char *argv[])
     if (!init(argc, argv))
     {
         LOGM_ERROR(TAG, "*** %s: An instance of Device Client is already running.", DC_FATAL_ERROR);
-        deviceClientAbort("An instance of Device Client is already running.");
+        deviceClientAbort("An instance of Device Client is already running.", EXIT_FAILURE);
     }
 #endif
 
@@ -356,7 +357,7 @@ int main(int argc, char *argv[])
     if (!resourceManager.get()->initialize(config.config, features))
     {
         LOGM_ERROR(TAG, "*** %s: Failed to initialize AWS CRT SDK.", DC_FATAL_ERROR);
-        deviceClientAbort("Failed to initialize AWS CRT SDK");
+        deviceClientAbort("Failed to initialize AWS CRT SDK", EXIT_FAILURE);
     }
 
 #if !defined(EXCLUDE_FP) && !defined(DISABLE_MQTT)
@@ -384,7 +385,7 @@ int main(int argc, char *argv[])
                 "Please verify your AWS IoT credentials, "
                 "configuration, Fleet Provisioning Template, claim certificate and policy used. ***",
                 DC_FATAL_ERROR);
-            deviceClientAbort("Fleet provisioning failed");
+            deviceClientAbort("Fleet provisioning failed", EXIT_FAILURE);
         }
         resourceManager->disconnect();
     }
@@ -395,8 +396,10 @@ int main(int argc, char *argv[])
             TAG,
             "*** %s: Fleet Provisioning configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration. Fleet Provisioning configuration is enabled but feature is not "
-                          "compiled into binary.");
+        deviceClientAbort(
+            "Invalid configuration. Fleet Provisioning configuration is enabled but feature is not "
+            "compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -415,7 +418,7 @@ int main(int argc, char *argv[])
             TAG,
             "*** %s: Secure Element configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration");
+        deviceClientAbort("Invalid configuration", EXIT_FAILURE);
     }
     else
     {
@@ -429,7 +432,8 @@ int main(int argc, char *argv[])
             "*** %s: Secure Element configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. Secure Element configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. Secure Element configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -453,7 +457,7 @@ int main(int argc, char *argv[])
             TAG,
             "*** %s: Config Shadow configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration");
+        deviceClientAbort("Invalid configuration", EXIT_FAILURE);
     }
 #endif
 
@@ -477,7 +481,8 @@ int main(int argc, char *argv[])
         LOGM_ERROR(
             TAG, "*** %s: Jobs configuration is enabled but feature is not compiled into binary.", DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. Config Shadow configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. Config Shadow configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -502,8 +507,10 @@ int main(int argc, char *argv[])
             TAG,
             "*** %s: Secure Tunneling configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration. Secure Tunneling configuration is enabled but feature is not "
-                          "compiled into binary.");
+        deviceClientAbort(
+            "Invalid configuration. Secure Tunneling configuration is enabled but feature is not "
+            "compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -529,7 +536,8 @@ int main(int argc, char *argv[])
             "*** %s: Device Defender configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. Device Defender configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. Device Defender configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -555,7 +563,8 @@ int main(int argc, char *argv[])
             "*** %s: Sample Shadow configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. Sample Shadow configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. Sample Shadow configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -581,7 +590,8 @@ int main(int argc, char *argv[])
             "*** %s: PubSub sample configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. PubSub sample configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. PubSub sample configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 
@@ -607,7 +617,8 @@ int main(int argc, char *argv[])
             "*** %s: Sensor Publish configuration is enabled but feature is not compiled into binary.",
             DC_FATAL_ERROR);
         deviceClientAbort(
-            "Invalid configuration. Sensor Publish configuration is enabled but feature is not compiled into binary.");
+            "Invalid configuration. Sensor Publish configuration is enabled but feature is not compiled into binary.",
+            EXIT_FAILURE);
     }
 #endif
 


### PR DESCRIPTION
### Motivation
- Secure tunneling component was failing to clean up the threads opened for each new tunnel. To resolve the issue, we are closing Device Client with `SIGTERM` signal. This will make sure that on tunnel close signal, we will send process termination signal which will eventually close all threads and free up all memory to avoid memory leak.


### Modifications
#### Change summary
- Calling signal termination from tunnel close callback 
- Updated abort function to pass in exit code. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
- Tested locally by creating private component. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
