### PR TITLE
Fixed bug to read SIGTERM signal when sent form kernel

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -348,6 +348,7 @@ int main(int argc, char *argv[])
     int received_signal;
     sigaddset(&sigset, SIGINT);
     sigaddset(&sigset, SIGHUP);
+    sigaddset(&sigset, SIGTERM);
     sigprocmask(SIG_BLOCK, &sigset, nullptr);
 
     auto listener = std::make_shared<DefaultClientBaseNotifier>();


### PR DESCRIPTION
### Motivation
fixed bug to read `SIGTERM` signal when sent form kernel


### Testing
 **Is your change tested? If not, please justify the reason.**  
Manually tested changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
