### PR TITLE
Updated google-test lib version to v1.12.0

### DIFF
--- a/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/device-client/amazonlinux/Dockerfile
@@ -46,9 +46,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz -o release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.12.0.tar.gz -o release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/base-images/device-client/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubi8/Dockerfile
@@ -59,9 +59,9 @@ RUN wget https://dist.opendnssec.org/source/softhsm-2.3.0.tar.gz \
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN curl -sSL https://github.com/google/googletest/archive/release-1.11.0.tar.gz -o release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.12.0.tar.gz -o release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/device-client/ubuntu/Dockerfile
@@ -46,9 +46,9 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3
 # Clone and build Google Test
 ###############################################################################
 WORKDIR /tmp
-RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://github.com/google/googletest/archive/release-1.11.0.tar.gz \
-    && tar xf release-1.11.0.tar.gz \
-    && cd googletest-release-1.11.0 \
+RUN wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://github.com/google/googletest/archive/release-1.12.0.tar.gz \
+    && tar xf release-1.12.0.tar.gz \
+    && cd googletest-release-1.12.0 \
     && cmake -DBUILD_SHARED_LIBS=ON . \
     && make \
     && cp -a googletest/include/gtest /usr/include/ \

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses-ubi8.txt
@@ -377,7 +377,7 @@ Public License instead of this License.
 
 ------
 
-** Google Test 1.10.0; version 1.10.0 -- https://github.com/google/googletest/blob/v1.10.x/LICENSE
+** Google Test 1.12.0; version 1.12.0 -- https://github.com/google/googletest/blob/v1.12.x/LICENSE
 Copyright 2008, Google Inc.
 All rights reserved.
 

--- a/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
+++ b/.github/docker-images/oss-compliance/build-from-source-packages/build-from-source-package-licenses.txt
@@ -343,7 +343,7 @@ Public License instead of this License.
 
 ------
 
-** Google Test 1.10.0; version 1.10.0 -- https://github.com/google/googletest/blob/v1.10.x/LICENSE
+** Google Test 1.12.0; version 1.12.0 -- https://github.com/google/googletest/blob/v1.12.x/LICENSE
 Copyright 2008, Google Inc.
 All rights reserved.
 

--- a/CMakeLists.txt.gtest
+++ b/CMakeLists.txt.gtest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           release-1.10.0
+        GIT_TAG           release-1.12.0
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CONFIGURE_COMMAND ""

--- a/integration-tests/CMakeLists.txt.gtest
+++ b/integration-tests/CMakeLists.txt.gtest
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           release-1.11.0
+        GIT_TAG           release-1.12.0
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CMAKE_ARGS        -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
### Motivation
- Issue number: #428 
- With newer version of `gcc` lib used on Ubuntu 22, device client is failing to download and use google-test lib. We use google-test for unit testing. This issue was resolved by google-test developers in the latest version of the library. Updating the google-test lib version used in Device Client to resolve this build failure issue. 


### Modifications
#### Change summary
- Updated google-test lib version to v1.12.0

#### Revision diff summary
N/A

### Testing
- Manually tested on Ubuntu 22
- Tested changes on CI build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
