### PR TITLE
Fix building against uclibc

### DIFF
--- a/source/util/StringUtils.h
+++ b/source/util/StringUtils.h
@@ -3,6 +3,7 @@
 
 #include <aws/crt/JsonObject.h>
 #include <aws/crt/Types.h>
+#include <cstdarg>
 #include <string>
 
 using namespace Aws::Crt;


### PR DESCRIPTION
Add #include <cstdarg> to StringUtils.h to fix the following error: error: 'va_list' has not been declared

### Motivation
- Please give a brief description for the background of this change.
- Issue number: 


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
