### PR TITLE
Make building tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,4 +265,6 @@ if (BUILD_TEST_DEPS)
             ${CMAKE_BINARY_DIR}/googletest-build)
 endif ()
 
-add_subdirectory(test)
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif(BUILD_TESTS)


### PR DESCRIPTION
Tests are not needed nor wanted when cross-compiling for an embedded environment such as Buildroot. Add a guard around add_subdirectory(test)

### Motivation
- I am porting several packages to the Buildroot embedded SDK. Buildroot does not need nor want to build tests for packages.

### Modifications
#### Change summary
Please describe what changes are included in this pull request. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
Built with buildroot 2023.11
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
