### PR TITLE
Disabled jobs and secure tunneling if they are not compiled into binary

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -17,6 +17,7 @@
 
 #endif
 
+#include "../SharedCrtResourceManager.h"
 #include "../util/FileUtils.h"
 #include "../util/MqttUtils.h"
 #include "../util/ProxyUtils.h"
@@ -2641,6 +2642,14 @@ bool Config::ParseCliArgs(int argc, char **argv, CliArgs &cliArgs)
 
 bool Config::init(const CliArgs &cliArgs)
 {
+#if defined(EXCLUDE_JOBS)
+    config.jobs.enabled = false;
+#endif
+
+#if defined(EXCLUDE_ST)
+    config.tunneling.enabled = false;
+#endif
+
     try
     {
         string filename = Config::DEFAULT_CONFIG_FILE;


### PR DESCRIPTION
### Motivation
- Jobs and Secure Tunneling feature in Device Client are enabled by default. Added code for disabling jobs and secure tunneling feature if the features are not compiled in the binary. 

### Modifications
#### Change summary
Disabled jobs and secure tunneling if they are not compiled into binary

#### Revision diff summary
N/A

### Testing
 * Manually tested on an Ubuntu 20 system. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
