### PR TITLE
Fix configure_file output path by adding CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ if (BUILD_SDK)
     set(BUILD_DEPS ON CACHE BOOL "Build dependencies for the AWS SDK" FORCE)
     set(USE_OPENSSL ON CACHE BOOL "Use OpenSSL instead of aws-lc" FORCE)
     configure_file(CMakeLists.txt.awssdk
-            aws-iot-device-sdk-cpp-v2-download/CMakeLists.txt)
+            ${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-download)
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
@@ -248,7 +248,7 @@ endif ()
 if (BUILD_TEST_DEPS)
     # Download and unpack googletest at configure time
     configure_file(CMakeLists.txt.gtest
-            googletest-download/CMakeLists.txt)
+            ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
     execute_process(COMMAND ${CMAKE_COMMAND} --build .


### PR DESCRIPTION
### Motivation
I am trying to build the aws-iot-device-client with BUILD_SDK=OFF and where the CMake build directory is not placed directly under the aws-iot-device-client. The build failed, reporting (for the googletest case):

```
CMake Error at aws-iot-device-client/CMakeLists.txt:264 (add_subdirectory):
  add_subdirectory given source "/home/x/test/build/googletest-src" which
  is not an existing directory.
```
The motivation for having the build directory in a non-standard location is to build aws-iot-device-client against a seperate checkout of the SDK along with other software that uses the SDK as part of a larger cross-compile build.

### Modifications
#### Change summary
The solution is to add ${CMAKE_BINARY_DIR} to the output argument of the configure_file CMake function. With this, the CMakeLists.txt.gtest or CMakeLists.txt.awssdk file will correctly be copied to the build/binary directory and the build completes successfully.

### Testing
Failure case:
Example top level CMakeLists.txt which is part of larger build:
```
cmake_minimum_required(VERSION 3.10)
project(my-aws-project)
add_subdirectory(aws-iot-device-sdk-cpp-v2)
add_subdirectory(aws-iot-device-client)
```
Test steps:
```
git clone https://github.com/awslabs/aws-iot-device-client.git
git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
pushd aws-iot-device-sdk-cpp-v2; git submodule update --init --recursive; popd
mkdir build
cd build
cmake ../ -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN -DBUILD_SDK=OFF
#
This fails!
```
This is fixed with this pull request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
