### PR TITLE
Removed number of slash validation for MQTT topics

### DIFF
--- a/source/util/MqttUtils.cpp
+++ b/source/util/MqttUtils.cpp
@@ -24,17 +24,6 @@ bool MqttUtils::ValidateAwsIotMqttTopicName(std::string topic)
         topic = reserved_topic.suffix();
     }
 
-    const std::size_t count_slashes = std::count(topic.cbegin(), topic.cend(), '/');
-    if (count_slashes > MAX_NUMBER_OF_FORWARD_SLASHES)
-    {
-        LOGM_ERROR(
-            TAG,
-            "Number of forward slashes in topic (%lu) exceeds maximum (%lu)",
-            count_slashes,
-            MAX_NUMBER_OF_FORWARD_SLASHES);
-        return false;
-    }
-
     // Since std::string is based on char, the size of the string and number of UTF8 chars is same.
     if (topic.size() > MAX_LENGTH_OF_TOPIC)
     {

--- a/source/util/MqttUtils.h
+++ b/source/util/MqttUtils.h
@@ -18,15 +18,10 @@ namespace Aws
                     //
                     // https://docs.aws.amazon.com/general/latest/gr/iot-core.html#message-broker-limits
                     //
-                    // A topic in a publish or subscribe request can have no more than 7 forward slashes (/).
-                    // This excludes the first 3 slashes in the mandatory segments for
-                    // Basic Ingest topics ($AWS/rules/rule-name/).
-                    //
                     // The topic passed to AWS IoT Core when sending a publish request can be no larger
                     // than 256 bytes of UTF-8 encoded characters. This excludes the first 3 mandatory
                     // segments for Basic Ingest topics ($AWS/rules/rule-name/).
                     //
-                    static constexpr std::size_t MAX_NUMBER_OF_FORWARD_SLASHES{7};
                     static constexpr std::size_t MAX_LENGTH_OF_TOPIC{256};
 
                     /**

--- a/test/config/TestConfig.cpp
+++ b/test/config/TestConfig.cpp
@@ -1310,41 +1310,6 @@ TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopicEmpty)
     ASSERT_FALSE(settings.enabled);
 }
 
-TEST_F(ConfigTestFixture, SensorPublishInvalidConfigMqttTopic)
-{
-    constexpr char jsonString[] = R"(
-{
-    "endpoint": "endpoint value",
-    "cert": "/tmp/aws-iot-device-client-test-file",
-    "root-ca": "/tmp/aws-iot-device-client-test/AmazonRootCA1.pem",
-    "key": "/tmp/aws-iot-device-client-test-file",
-    "thing-name": "thing-name value",
-    "sensor-publish": {
-        "sensors": [
-            {
-                "addr": "/tmp/sensors/my-sensor-server",
-                "eom_delimiter": "[\r\n]+",
-                "mqtt_topic": "////////my-sensor-data"
-            }
-        ]
-    }
-})";
-    JsonObject jsonObject(jsonString);
-    JsonView jsonView = jsonObject.View();
-
-    PlainConfig config;
-    config.LoadFromJson(jsonView);
-
-#if defined(EXCLUDE_SENSOR_PUBLISH)
-    GTEST_SKIP();
-#endif
-    ASSERT_FALSE(config.Validate()); // Invalid mqtt_topic.
-    ASSERT_TRUE(config.sensorPublish.enabled);
-    ASSERT_EQ(config.sensorPublish.settings.size(), 1);
-    const auto &settings = config.sensorPublish.settings[0];
-    ASSERT_FALSE(settings.enabled);
-}
-
 TEST_F(ConfigTestFixture, SensorPublishInvalidConfigEomDelimiter)
 {
     constexpr char jsonString[] = R"(

--- a/test/util/TestMqttUtils.cpp
+++ b/test/util/TestMqttUtils.cpp
@@ -27,21 +27,6 @@ TEST(MqttUtils, ReservedTopicValid)
     ASSERT_TRUE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
 }
 
-TEST(MqttUtils, TopicNotValidExceedsMaxSlashes)
-{
-    std::string topic(MqttUtils::MAX_NUMBER_OF_FORWARD_SLASHES + 1, '/');
-
-    ASSERT_FALSE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
-}
-
-TEST(MqttUtils, TopicValidExceedsMaxSlashesWithReservedTopic)
-{
-    std::string topic(RESERVED_TOPIC);
-    std::fill_n(std::back_inserter(topic), MqttUtils::MAX_NUMBER_OF_FORWARD_SLASHES, '/');
-
-    ASSERT_TRUE(MqttUtils::ValidateAwsIotMqttTopicName(topic));
-}
-
 TEST(MqttUtils, TopicNotValidExceedsMaxLength)
 {
     std::string topic(MqttUtils::MAX_LENGTH_OF_TOPIC + 1, 'A');


### PR DESCRIPTION
### Motivation
- Number of slash is not consistent in different topics and reserved topics.
- The rule applied for basic ingestion for number of slash is different from other reserved topics. 
- We have more validation tests added on the cloud side so we do not have to test this on client side.


### Modifications
#### Change summary
- Removed the MQTT topic validation for number of slashes.
- Remove unit tests added for testing the slash limit in the MQTT topic.

#### Revision diff summary
N/A

### Testing
- Manually tested changes locally. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
