### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -55,7 +55,7 @@ jobs:
         id: get-version
         run: |
           version=$(docker run ${{ steps.build-device-client.outputs.imageid }} --version)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
   build-docker-image-ubuntu-x86_64:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -52,7 +52,7 @@ jobs:
         id: get-version
         run: |
           version=$(docker run ${{ steps.build-device-client.outputs.imageid }} --version)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
   build-docker-image-ubuntu-x86_64:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter