### PR TITLE
Fix DC abort logic for Secure Element

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -414,14 +414,10 @@ int main(int argc, char *argv[])
     attemptConnection();
 #endif
 
-#if defined(EXCLUDE_SECURE_ELEMENT) && !defined(DISABLE_MQTT)
+#if !defined(EXCLUDE_SECURE_ELEMENT) && !defined(DISABLE_MQTT)
     if (config.config.secureElement.enabled)
     {
-        LOGM_ERROR(
-            TAG,
-            "*** %s: Secure Element configuration is enabled but feature is not compiled into binary.",
-            DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration", EXIT_FAILURE);
+        LOG_INFO(TAG, "Secure element is enabled");
     }
     else
     {


### PR DESCRIPTION
If Secure Element is compiled into binary and enabled via configuration it shouldn't abort.

### Motivation
- Please give a brief description for the background of this change.
- Issue number: 


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
