### PR TITLE
Secure Element feature build bug fix

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -414,16 +414,8 @@ int main(int argc, char *argv[])
     attemptConnection();
 #endif
 
-#if defined(EXCLUDE_SECURE_ELEMENT) && !defined(DISABLE_MQTT)
-    if (config.config.secureElement.enabled)
-    {
-        LOGM_ERROR(
-            TAG,
-            "*** %s: Secure Element configuration is enabled but feature is not compiled into binary.",
-            DC_FATAL_ERROR);
-        deviceClientAbort("Invalid configuration", EXIT_FAILURE);
-    }
-    else
+#if !defined(EXCLUDE_SECURE_ELEMENT) && !defined(DISABLE_MQTT)
+    if (!config.config.secureElement.enabled)
     {
         LOG_INFO(TAG, "Provisioning with Secure Elements is disabled");
     }


### PR DESCRIPTION
### Motivation
- Secure Element feature is not being stated even if it is enabled and is built in the artifact.


### Modifications
#### Change summary
- Fixed logical error to enable use of secure element feature when it is built in the artifact and is enabled. 

#### Revision diff summary
N/A

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
