### PR TITLE
write provisioned certificate to "active-certificate.pem.crt"

### DIFF
--- a/source/fleetprovisioning/FleetProvisioning.h
+++ b/source/fleetprovisioning/FleetProvisioning.h
@@ -172,7 +172,15 @@ namespace Aws
                      * @param response from IotIdentity CreateKeysAndCertificate call
                      * @return returns true if successfully written to directory
                      */
-                    bool WriteCertToDirectory(Iotidentity::CreateKeysAndCertificateResponse *response, std::string fileName);
+                    bool WriteKeyAndCertToDirectory(Iotidentity::CreateKeysAndCertificateResponse *response, std::string fileName);
+
+                    /**
+                     * \brief writes contents of the cert from CSR to the device client config directory.
+                     *
+                     * @param response from IotIdentity CreateCertificateFromCsrResponse call
+                     * @return returns true if successfully written to directory
+                     */
+                    bool WriteCSRCertToDirectory(Iotidentity::CreateCertificateFromCsrResponse *response, std::string fileName);
 
                     /**
                      * \brief creates a new certificate and private key using the AWS certificate authority

--- a/source/fleetprovisioning/FleetProvisioning.h
+++ b/source/fleetprovisioning/FleetProvisioning.h
@@ -167,12 +167,19 @@ namespace Aws
                     bool collectSystemInformation;
 
                     /**
+                     * \brief writes contents of the cert and key to the device client config directory.
+                     *
+                     * @param response from IotIdentity CreateKeysAndCertificate call
+                     * @return returns true if successfully written to directory
+                     */
+                    bool WriteCertToDirectory(Iotidentity::CreateKeysAndCertificateResponse *response, std::string fileName);
+
+                    /**
                      * \brief creates a new certificate and private key using the AWS certificate authority
                      *
                      * @param identityClient used for subscribing and publishing request for creating resources
                      * @return returns true if resources are created successfully
                      */
-
                     bool CreateCertificateAndKey(Iotidentity::IotIdentityClient identityClient);
 
                     /**


### PR DESCRIPTION
### Motivation
- create a static filepath that gets overwritten upon a successful retry of the Fleet provisioning workflow.
- QoL for specific applications on the device that may need the x509 certificate to reside at a guaranteed location.

### Modifications
#### Change summary
- extracted logic into a private function for calling it twice. First time with certificate ID and second time with the "active" prefix

### Testing
- manually tested /w FP template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
