### PR TITLE
Modified condition to create default sample shadow directory

### DIFF
--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -1773,12 +1773,13 @@ bool PlainConfig::SampleShadow::LoadFromCliArgs(const CliArgs &cliArgs)
                 .c_str();
     }
 
-    // setting `shadowOutputFile` value to default if no value was passed by user via CLI or JSON config.
-    if ((!shadowOutputFile.has_value() || shadowOutputFile->empty()) && !createShadowOutputFile())
+    // setting `shadowOutputFile` value to default if no value was passed by user via CLI or JSON config, provided sample shadow feature is enabled.
+    if (enabled && ((!shadowOutputFile.has_value() || shadowOutputFile->empty()) && !createShadowOutputFile()))
     {
         return false;
     }
 
+    LOGM_INFO(Config::TAG, "Not creating directory %s since sample shadow is disabled", Config::DEFAULT_SAMPLE_SHADOW_OUTPUT_DIR);
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: https://github.com/awslabs/aws-iot-device-client/issues/452


### Modifications
#### Change summary
Modified condition to create default sample shadow directory only when the sample shadow feature is enabled and added corresponding logs


### Testing
Tested the changes locally on my linux instance


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
