### PR TITLE
Fix patch versioning to count the number of commits from last major minor

### DIFF
--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -39,7 +39,7 @@ endfunction()
 if (GIT_VERSION AND NOT ${GIT_INFO} STREQUAL "")
     message("-- Using Git to calculate AWS IoT Device Client version information...")
 
-    # Get first tag with major and minor of the latest latest tag. 
+    # Get first tag with major and minor of the latest tag. 
     execute_process(
         COMMAND bash -c "
             read LATEST_MAJOR_VERSION LATEST_MINOR_VERSION < <(git describe --abbrev=0 --tags | awk -F. '

--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -39,7 +39,7 @@ endfunction()
 if (GIT_VERSION AND NOT ${GIT_INFO} STREQUAL "")
     message("-- Using Git to calculate AWS IoT Device Client version information...")
 
-    # Get last tag from git - this only matches tags starting with v, so we ignore non-versioning tags
+    # Get first tag with major and minor of the latest latest tag. 
     execute_process(
         COMMAND bash -c "
             read LATEST_MAJOR_VERSION LATEST_MINOR_VERSION < <(git describe --abbrev=0 --tags | awk -F. '

--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -44,7 +44,6 @@ if (GIT_VERSION AND NOT ${GIT_INFO} STREQUAL "")
         COMMAND bash -c "
             read LATEST_MAJOR_VERSION LATEST_MINOR_VERSION < <(git describe --abbrev=0 --tags | awk -F. '
             {
-                orig_tag = \$0
                 gsub(/^v/, \"\", \$0)
 
                 split(\$0, parts, \".\")

--- a/CMakeLists.txt.versioning
+++ b/CMakeLists.txt.versioning
@@ -40,7 +40,21 @@ if (GIT_VERSION AND NOT ${GIT_INFO} STREQUAL "")
     message("-- Using Git to calculate AWS IoT Device Client version information...")
 
     # Get last tag from git - this only matches tags starting with v, so we ignore non-versioning tags
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags --match "v[0-9]*"
+    execute_process(
+        COMMAND bash -c "
+            read LATEST_MAJOR_VERSION LATEST_MINOR_VERSION < <(git describe --abbrev=0 --tags | awk -F. '
+            {
+                orig_tag = \$0
+                gsub(/^v/, \"\", \$0)
+
+                split(\$0, parts, \".\")
+                LATEST_MAJOR_VERSION = parts[1]
+                LATEST_MINOR_VERSION = parts[2]
+                print LATEST_MAJOR_VERSION, LATEST_MINOR_VERSION
+
+            }')
+            git tag --sort=creatordate | grep -E \"^v?\${LATEST_MAJOR_VERSION}\.\${LATEST_MINOR_VERSION}(\\.\[0-9]+)?\" | head -n 1
+        "
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE ${PROJECT_NAME}_VERSION_STRING
         OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change:
This PR updates the patch versioning by counting the number of commits that happened from the last major minor version tag as the patch number instead of counting from the last patch release so that the patch version number will always be incremental. 

### Modifications
#### Change summary
Please describe what changes are included in this pull request. 

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
