### PR TITLE
Remove Github secrets and migrate to Github OIDC for AWS Authentication

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,11 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.ECR_USER_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_USER_AWS_KEY_SECRET }}
+          role-to-assume: arn:aws:iam::316548805944:role/GitHubActionsOIDCRole
           aws-region: us-east-1
       - name: Login to ECR
         run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.

In order to alleviate potential security risks, we need to migrate to short-term temporary credentials instead of long-term access keys. Hence we plan to move to Github OIDC to achieve this requirement.


### Modifications
#### Change summary
Please describe what changes are included in this pull request. 
- Removed Github secrets that were being used for authentication with AWS.
- Updated configure-aws-credentials to v2 which is the recommended version for OIDC support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
