### PR TITLE
Trigger Build CI on Tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - '*'
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - '*'
-
 env:
   PACKAGE_NAME: aws-iot-device-client
   ECR_BASE_REPO: aws-iot-device-client/aws-iot-device-client-base-images
@@ -42,7 +43,7 @@ jobs:
       - name: Archive ubuntu Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -50,7 +51,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.ubuntu.x64.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -81,7 +82,7 @@ jobs:
       - name: Archive amazonlinux Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.amazonlinux.x64.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -89,7 +90,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.amazonlinux.x64.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -120,7 +121,7 @@ jobs:
       - name: Archive rhel-ubi8 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -128,7 +129,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.rhel.x64.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -211,7 +212,7 @@ jobs:
       - name: Archive armhf32 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -219,7 +220,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.armhf.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -250,7 +251,7 @@ jobs:
       - name: Archive mips32 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -258,7 +259,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.mips.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -289,7 +290,7 @@ jobs:
       - name: Archive aarch64 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -297,7 +298,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.aarch64.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -328,7 +329,7 @@ jobs:
       - name: Archive aarch64 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.ppc64.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -336,7 +337,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.ppc64.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -367,7 +368,7 @@ jobs:
       - name: Archive aarch64 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.ppc64le.${{ env.PACKAGE_NAME }}.build.static"
           path: |
@@ -375,7 +376,7 @@ jobs:
       - name: Archive setup files
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "DC.linux.ppc64le.${{ env.PACKAGE_NAME }}.setup.static"
           path: |
@@ -406,7 +407,7 @@ jobs:
       - name: Archive ST Ubuntu aarch64 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "ST.ubuntu.x64.${{ env.PACKAGE_NAME }}"
           path: |
@@ -437,7 +438,7 @@ jobs:
       - name: Archive ST Ubuntu aarch64 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "ST.ubuntu.aarch64.${{ env.PACKAGE_NAME }}"
           path: |
@@ -468,7 +469,7 @@ jobs:
       - name: Archive st armhf32 Build Artifact
         uses: actions/upload-artifact@v4
         # Run for main branch only
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: "ST.linux.armhf.${{ env.PACKAGE_NAME }}"
           path: |

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -360,19 +360,20 @@ jobs:
             public.ecr.aws/${{ env.ECR_TEST_RUNNER_REPO }}:x86_64-ubuntu-${{ needs.versioning.outputs.version }}
             public.ecr.aws/${{ env.ECR_TEST_RUNNER_REPO }}:x86_64-ubuntu-latest
           platforms: linux/amd64
-      - name: Assume Role for Integration Test
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.DC_AWS_ACCOUNT_ID }}:role/integration-test-role
-          aws-region: us-east-1          
-      - name: Run Tests
+      - name: Print masked AWS environment vars
+        run: |
+          echo "Verifying GitHub environment vars:"
+          echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:0:5}*****"
+          echo "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:0:5}*****"
+          echo "AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:0:5}*****"             
+      - name: Run Integration Tests container with OIDC role credentials
         env:
           IOT_ENDPOINT: ${{ secrets.IOT_ENDPOINT }}
           CERTIFICATE: ${{ secrets.CLAIM_CERTIFICATE }}
           DEVICE_KEY_SECRET: ${{ secrets.FP_DEVICE_KEY_SECRET }}
           AMAZON_ROOT_CA: ${{ secrets.AMAZON_ROOT_CA }}
         run: |
-          docker run -e IOT_ENDPOINT="$(echo $IOT_ENDPOINT)" -e CERTIFICATE="$(echo $CERTIFICATE)" -e DEVICE_KEY_SECRET="$(echo $DEVICE_KEY_SECRET)" -e AMAZON_ROOT_CA="$(echo $AMAZON_ROOT_CA)" -e THING_NAME=fleetprovisioning ${{ steps.build-test-runner.outputs.imageid }} --skip-st --clean-up
+          docker run -e AWS_ACCESS_KEY_ID="(echo $AWS_ACCESS_KEY_ID)" -e AWS_SECRET_ACCESS_KEY="(echo $AWS_SECRET_ACCESS_KEY)" -e AWS_SESSION_TOKEN="$(echo $AWS_SESSION_TOKEN)" -e IOT_ENDPOINT="$(echo $IOT_ENDPOINT)" -e CERTIFICATE="$(echo $CERTIFICATE)" -e DEVICE_KEY_SECRET="$(echo $DEVICE_KEY_SECRET)" -e AMAZON_ROOT_CA="$(echo $AMAZON_ROOT_CA)" -e THING_NAME=fleetprovisioning ${{ steps.build-test-runner.outputs.imageid }} --clean-up
   e2e-tests-ubuntu-aarch64:
     runs-on: ubuntu-latest
     if: ${{ false }} # Disabled for now. aarch64 local proxy build takes too long


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.

Fix versioning of information for every new Tagged release commit that we create.


### Modifications
#### Change summary

Updated Build CI logic to trigger and upload artifacts upon Tag creations as well




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
