### PR TITLE
Update aws-iot-device-sdk-cpp-v2 to v1.42.0

### DIFF
--- a/CMakeLists.txt.awssdk
+++ b/CMakeLists.txt.awssdk
@@ -5,7 +5,7 @@ project(aws-iot-device-sdk-cpp-v2-download NONE)
 include(ExternalProject)
 ExternalProject_Add(aws-iot-device-sdk-cpp-v2
         GIT_REPOSITORY          https://github.com/aws/aws-iot-device-sdk-cpp-v2.git
-        GIT_TAG                 74c8b683ebe5b1cbf484f6acaa281f56aaa63948
+        GIT_TAG                 v1.42.0
         SOURCE_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-src"
         BINARY_DIR              "${CMAKE_BINARY_DIR}/aws-iot-device-sdk-cpp-v2-build"
         CONFIGURE_COMMAND       ""

--- a/source/sensor-publish/Socket.h
+++ b/source/sensor-publish/Socket.h
@@ -71,8 +71,12 @@ namespace Aws
                         aws_socket_on_connection_result_fn *on_connection_result,
                         void *user_data) override
                     {
-                        return aws_socket_connect(
-                            &socket, remote_endpoint, event_loop, on_connection_result, user_data);
+                        aws_socket_connect_options connect_options{};
+                        connect_options.remote_endpoint = remote_endpoint;
+                        connect_options.event_loop = event_loop;
+                        connect_options.on_connection_result = on_connection_result;
+                        connect_options.user_data = user_data;
+                        return aws_socket_connect(&socket, &connect_options);
                     }
 
                     /**

--- a/source/tunneling/TcpForward.cpp
+++ b/source/tunneling/TcpForward.cpp
@@ -59,7 +59,13 @@ namespace Aws
                     aws_event_loop *eventLoop = aws_event_loop_group_get_next_loop(
                         mSharedCrtResourceManager->getEventLoopGroup()->GetUnderlyingHandle());
 
-                    aws_socket_connect(&mSocket, &endpoint, eventLoop, sOnConnectionResult, this);
+                    aws_socket_connect_options connect_options{};
+                    connect_options.remote_endpoint = &endpoint;
+                    connect_options.event_loop = eventLoop;
+                    connect_options.on_connection_result = sOnConnectionResult;
+                    connect_options.user_data = this;
+
+                    aws_socket_connect(&mSocket, &connect_options);
 
                     return 0;
                 }

--- a/test/sensor-publish/TestSensor.cpp
+++ b/test/sensor-publish/TestSensor.cpp
@@ -41,15 +41,21 @@ class SensorTest : public ::testing::Test
         // Initialize default allocator.
         allocator = aws_default_allocator();
 
-        // Initialize and start the event loop.
-        eventLoop = aws_event_loop_new_default(allocator, aws_high_res_clock_get_ticks);
+        // Initialize event loop group and get an event loop from it.
+        aws_event_loop_group_options elg_options;
+        AWS_ZERO_STRUCT(elg_options);
+        elg_options.loop_count = 1;
+        elg_options.shutdown_options = nullptr;
+        eventLoopGroup = aws_event_loop_group_new(allocator, &elg_options);
+        eventLoop = aws_event_loop_group_get_next_loop(eventLoopGroup);
     }
 
-    void TearDown() override { aws_event_loop_destroy(eventLoop); }
+    void TearDown() override { aws_event_loop_group_release(eventLoopGroup); }
 
     PlainConfig::SensorPublish::SensorSettings settings;
     aws_allocator *allocator;
     std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection;
+    aws_event_loop_group *eventLoopGroup;
     aws_event_loop *eventLoop;
 };
 


### PR DESCRIPTION
- Update GIT_TAG in CMakeLists.txt.awssdk from v1.30.3 commit to v1.42.0
- Fix aws_socket_connect API change: use aws_socket_connect_options struct
- Fix event loop API changes in tests: use aws_event_loop_group_new() instead of removed aws_event_loop_new_default/run/stop functions